### PR TITLE
Only override Patroni namespace if env var is set

### DIFF
--- a/scripts/augment_patroni_configuration.py
+++ b/scripts/augment_patroni_configuration.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
         # Other provisions are also available, but this ensures no naming collisions
         # for deployments in separate Kubernetes Namespaces will occur
         # https://github.com/zalando/patroni/blob/master/docs/ENVIRONMENT.rst#globaluniversal
-        if 'etcd' in pgconfig:
+        if 'etcd' in pgconfig and os.getenv('POD_NAMESPACE'):
             pgconfig['namespace'] = os.getenv('POD_NAMESPACE')
 
         f.seek(0)


### PR DESCRIPTION
The previous approach did not consider the case where the container may
not have the environment variable set.

We were running into:

      File "/usr/lib/python3/dist-packages/patroni/dcs/__init__.py", line 528, in __init__
        self._base_path = re.sub('/+', '/', '/'.join(['', config.get('namespace', 'service'), config['scope']]))
    TypeError: sequence item 1: expected str instance, dict found

errors because of this.