### PR TITLE
Allow custom TimescaleDB builds from source dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .build*
+timescaledb-private/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,8 +53,8 @@ build.feature-branch:
   tags: [ "docker" ]
   script:
     - make build test
+    - make push push-multinode
     - docker image ls
-    - make push
 
 build.master-branch:
   stage: build


### PR DESCRIPTION
The use case that is required for this is that multinode is on a private
branch. As pulling private git repositories from within Docker requires
a deploy key or other SSH key injection, this is not readily available.

By allowing you to specify a directory, any developer can create a
directory and build Docker images against that directory.