### PR TITLE
Optimize building Docker images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,12 +49,12 @@ before_script:
 
 build.feature-branch:
   stage: build
-  except: [ "master", "release" ]
+  except: [ "master", "release", "tags" ]
   tags: [ "docker" ]
   script:
-    - make build test
-    - docker image ls
+    - make test
     - make push
+    - docker image ls
 
 build.master-branch:
   stage: build
@@ -73,6 +73,6 @@ build.release:
     TAG: ${CI_COMMIT_TAG}
     GIT_REV: ${CI_COMMIT_TAG}
   script:
-    - make build test
+    - make test
     - make push-all
     - docker image ls


### PR DESCRIPTION
By changing the order of instructions, most variants of the Docker image
will be sharing the same building layer.

By pushing down the steps that depend on variables, like PG_MAJOR, or
GIT_INFO_JSON, that step only needs to be built after all the Patroni
dependencies etc. have been installed.

The cicd config has changed a little, to ensure that when we tag we do
not have 2 build pipelines running, which was previously the case and
that is just wasting time and other resources.

Some slight reordering of the steps in cicd to ensure the list of Docker
images is displayed at the bottom, for human readibility of the cicd
pipeline output.

Added one build-time dependency, which is also removed to satisfy a
build requirement for multi-node.