### PR TITLE
Release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.2.2] - 2019-09-11
+
+### Changed
+* TimescaleDB 1.4.2 was released, rebuilding the Docker image to include that version
+
 ## [v0.2.1] - 2019-09-06
 
 ### Changed


### PR DESCRIPTION
TimescaleDB 1.4.2 was released,
rebuilding the Docker image to include that version.

No actual code changes to see here, just another CI/CD run that will fetch the latest TimescaleDB release as well.