### PR TITLE
Run timescaledb-tune for the PG_MAJOR version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+These are changes that will probably be included in the next release.
+
+### Added
+### Changed
+### Removed
+### Fixed
+* Invoke timescaledb-tune explicitly with the PostgreSQL version we want
+
 ## [v0.2.3] - 2019-10-09
 ### Added
 * Install [tsdbadmin](https://github.com/timescale/savannah-tsdbadmin/) scripts into postgres database


### PR DESCRIPTION
timescaledb-tune relies on pg_config to determine the PostgreSQL version
and other details if the version is not specified.
This works fine if both PG_MAJOR and the current latest public release
are equal, however currently we build against PostgreSQL 11, whereas
PostgreSQL 12 is already available.

By default, pg_config on Debian is the latest, so timescaledb-tune was
trying to run a tuning session for PostgreSQL 12 - which it currently
does not support.

By being explicit we ensure this error does not occur again.