### PR TITLE
Allow builds from specific repository and tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ These are changes that will probably be included in the next release.
 
 ### Added
  * Include pgextwlist to allow extension whitelisting
+ * Possibility to build a Docker image for a given repository and/or tag
 ### Changed
 ### Removed
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,19 @@
 PG_MAJOR?=11
 PGVERSION=pg$(PG_MAJOR)
 
+# These variables have to do with this Docker repository
 GIT_COMMIT=$(shell git describe --always --tag --long --abbrev=8)
 GIT_BRANCH=$(shell git symbolic-ref --short HEAD)
 GIT_REMOTE=$(shell git config --get remote.origin.url | sed 's/.*@//g')
 GIT_STATUS=$(shell git status --porcelain | paste -sd "," -)
 GIT_AUTHOR?=$(USER)
 GIT_REV?=$(shell git rev-parse HEAD)
+
+# These variables have to do with what software we pull in from github
+GITHUB_USER?=""
+GITHUB_TOKEN?=""
+GITHUB_REPO?="timescale/timescaledb"
+GITHUB_TAG?="master"
 
 # We store the GIT_INFO_JSON inside the Docker image if we build it using make
 # this ensures we always know if we have an image, what the git context was when
@@ -35,6 +42,12 @@ default: build
 	docker tag $(TIMESCALEDB_RELEASE_URL)-nov $(TIMESCALEDB_LATEST_URL)-nov
 	touch .build_$(TAG)_$(PGVERSION)_nov
 
+.build_$(TAG)_$(PGVERSION)_tag: Dockerfile
+	$(DOCKER_BUILD_COMMAND) -t $(TIMESCALEDB_RELEASE_URL) \
+		--build-arg GITHUB_REPO=$(GITHUB_REPO) --build-arg GITHUB_USER=$(GITHUB_USER) \
+		--build-arg GITHUB_TOKEN=$(GITHUB_TOKEN) --build-arg GITHUB_TAG=$(GITHUB_TAG) .
+	@touch .build_$(TAG)_$(PGVERSION)_tag
+
 .build_$(TAG)_$(PGVERSION): Dockerfile
 	$(DOCKER_BUILD_COMMAND) -t $(TIMESCALEDB_RELEASE_URL) .
 	docker tag $(TIMESCALEDB_RELEASE_URL) $(TIMESCALEDB_LATEST_URL)
@@ -45,6 +58,9 @@ build: .build_$(TAG)_$(PGVERSION)
 build-oss: .build_$(TAG)_$(PGVERSION)_oss
 
 build-nov: .build_$(TAG)_$(PGVERSION)_nov
+
+build-tag: .build_$(TAG)_$(PGVERSION)_tag
+	docker image ls $(TIMESCALEDB_RELEASE_URL)
 
 build-all: build build-oss build-nov
 
@@ -72,4 +88,4 @@ test: build
 clean:
 	rm -f *~ .build_*
 
-.PHONY: default build build-oss build-nov build-all push push-oss push-nov push-all test
+.PHONY: default build build-oss build-nov build-tag build-all push push-oss push-nov push-all test


### PR DESCRIPTION
This allows development snapshots, public/private beta's to build an
image containing only that version of TimescaleDB, but keeping
everything else the same.