### PR TITLE
Include pgextwlist libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 These are changes that will probably be included in the next release.
 
 ### Added
+ * Include pgextwlist to allow extension whitelisting
 ### Changed
 ### Removed
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ ARG TS_CUSTOMIZATION=""
 RUN for pg in ${PG_VERSIONS}; do \
         if [ -z "${TS_CUSTOMIZATION}" ]; then \
             # If no customizations are necessary, we'll just use the pgdg binary packages
-            apt-get install -y postgresql-${pg} postgresql-plpython3-${pg} postgresql-plperl-${pg} postgresql-server-dev-${pg}; \
+            apt-get install -y postgresql-${pg} postgresql-plpython3-${pg} postgresql-plperl-${pg} postgresql-server-dev-${pg} postgresql-${pg}-pgextwlist; \
         else \
             # We'll fetch the sources, let the customizations script have its way at the sources
             # and then compile and install the customized packages


### PR DESCRIPTION
This extension implements extension whitelisting, and will actively prevent
users from installing extensions not in the provided list. Also, this
extension implements a form of sudo facility in that the whitelisted
extensions will get installed as if superuser. Privileges are dropped before
handing the control back to the user.

The extension is not enabled by default.