### PR TITLE
Include latest minor versions of PG/TimescaleDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ These are changes that will probably be included in the next release.
 ### Removed
 ### Fixed
 
+## [v0.2.7] - 2019-11-14
+
+### Changed
+ * PostgreSQL 11.6 was released
+ * TimescaleDB 1.5.1 was released
+
+
 ## [v0.2.6] - 2019-11-06
 
 ### Changed


### PR DESCRIPTION
Well, 11.6 has not yet been fully released, but they debian packages are already there, so when triggering a new build *now* we'll get PostgreSQL 11.6 and TimescaleDB 1.5.1.