### PR TITLE
Use AWS CloudFront mirror for Debian packages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,8 @@ variables:
   REGISTRY_SECRET_NAME: registry-key-savannah-timescaledb-docker-patroni
   # Using the default mirrors caused a lot of timeouts previously
   DEBIAN_REPO_MIRROR: cdn-aws.deb.debian.org
+  # By using the previously built image, we can build the images very quickly
+  DOCKER_IMAGE_CACHE: --cache-from registry.gitlab.com/timescale/timescaledb-docker-ha:builder-pg11
 
 before_script:
   # NOTE: these credentials are created by the GitlabCI system, and are ephemeral. They are only
@@ -53,7 +55,10 @@ build.feature-branch:
   stage: build
   except: [ "master", "release", "tags" ]
   tags: [ "docker" ]
+  variables:
   script:
+    - docker pull registry.gitlab.com/timescale/timescaledb-docker-ha:builder-pg11
+    - make push-builder
     - make test
     - make push
     - docker image ls
@@ -63,6 +68,7 @@ build.master-branch:
   only: [ "master" ]
   tags: [ "docker" ]
   script:
+    - make push-builder
     - make test
     - make push-all
     - docker image ls

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN adduser --home /home/postgres --uid 1000 --disabled-password --gecos "" post
 ARG DEBIAN_REPO_MIRROR=""
 RUN echo 'APT::Install-Recommends "0";\nAPT::Install-Suggests "0";' > /etc/apt/apt.conf.d/01norecommend \
     && if [ "${DEBIAN_REPO_MIRROR}" != "" ]; then \
-        sed -i "s{http://*.debian.org{http://${DEBIAN_REPO_MIRROR}{g" /etc/apt/sources.list; \
+        sed -i "s{http://.*.debian.org{http://${DEBIAN_REPO_MIRROR}{g" /etc/apt/sources.list; \
     fi
 
 # Install the highlest level dependencies, like the PostgreSQL repositories,


### PR DESCRIPTION
When using the default package url we keep running into connection
errors. Why that is is unclear, but if it can be solved by using AWS
mirrors, what does it matter?