### PR TITLE
Update reported INSTALL_METHOD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,8 @@ RUN mkdir -p /build \
             git clone "https://github.com/${GITHUB_REPO}" /build/timescaledb; \
        fi
 
+ARG INSTALL_METHOD=docker-ha
+
 # If a specific GITHUB_TAG is provided, we will build that tag only. Otherwise
 # we build all the public (recent) releases
 RUN TS_VERSIONS=$(curl "https://api.github.com/repos/${GITHUB_REPO}/releases" \
@@ -123,7 +125,7 @@ RUN TS_VERSIONS=$(curl "https://api.github.com/repos/${GITHUB_REPO}/releases" \
         for ts in ${TS_VERSIONS}; do \
             cd /build/timescaledb && git reset HEAD --hard && git checkout ${ts} \
             && rm -rf build \
-            && PATH="/usr/lib/postgresql/${pg}/bin:${PATH}" ./bootstrap -DREGRESS_CHECKS=OFF -DPROJECT_INSTALL_METHOD="docker"${OSS_ONLY} \
+            && PATH="/usr/lib/postgresql/${pg}/bin:${PATH}" ./bootstrap -DREGRESS_CHECKS=OFF -DPROJECT_INSTALL_METHOD="${INSTALL_METHOD}"${OSS_ONLY} \
             && cd build && make -j 6 install || exit 1; \
         done; \
     done \

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,10 @@ TIMESCALEDB_BUILDER_URL?=$(TIMESCALEDB_IMAGE):builder-$(PGVERSION)
 TIMESCALEDB_RELEASE_URL?=$(TIMESCALEDB_IMAGE):$(TAG)-$(PGVERSION)
 TIMESCALEDB_LATEST_URL?=$(TIMESCALEDB_IMAGE):latest-$(PGVERSION)
 PG_PROMETHEUS?=0.2.2
+INSTALL_METHOD?="docker-ha"
 
 DOCKER_BUILD_COMMAND=docker build --build-arg GIT_INFO_JSON='$(GIT_INFO_JSON)' --build-arg PG_MAJOR=$(PG_MAJOR) \
-					 --build-arg PG_PROMETHEUS=$(PG_PROMETHEUS) --build-arg DEBIAN_REPO_MIRROR=$(DEBIAN_REPO_MIRROR) $(DOCKER_IMAGE_CACHE)
+					 --build-arg INSTALL_METHOD="$(INSTALL_METHOD)" --build-arg PG_PROMETHEUS=$(PG_PROMETHEUS) --build-arg DEBIAN_REPO_MIRROR=$(DEBIAN_REPO_MIRROR) $(DOCKER_IMAGE_CACHE)
 
 default: build
 
@@ -102,4 +103,3 @@ clean:
 	rm -f *~ .build_*
 
 .PHONY: default build builder build-postgis build-oss build-tag build-all push push-builder push-postgis push-oss push-all test
-


### PR DESCRIPTION
In order to be improve our telemetry and give us the ability to
observe how popular this image is, we give it a unique install
method. It is also overrideable so it can be set at build time for
different environments.