### PR TITLE
Release v0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 These are changes that will probably be included in the next release.
 
 ### Added
- * Remove stale pidfile if it exists
 ### Changed
 ### Removed
 ### Fixed
+
+## [v0.2.10] - 2020-03-20
+
+### Added
+ * Remove stale pidfile if it exists
+ * Include `strace` for debugging
+### Changed
+ * TimescaleDB 1.6.1 was released
+### Fixed
+ * Fail build if a single item in a loop fails
+### Removed
+ * Some perl dependencies of `pgBackRest`, which are no longer needed
+     as `pgBackRest` is now fully written in C
 
 ## [v0.2.9] - 2020-02-13
 


### PR DESCRIPTION
### Added
 * Remove stale pidfile if it exists
 * Include `strace` for debugging
### Changed
 * TimescaleDB 1.6.1 was released
### Fixed
 * Fail build if a single item in a loop fails
### Removed
 * Some perl dependencies of `pgBackRest`, which are no longer needed
     as `pgBackRest` is now fully written in C