### PR TITLE
Include some (tiny) tools in all Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,12 @@ RUN apt-get update \
     && curl -s -o - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
 # Some tools that are not strictly required for running PostgreSQL, but have a tiny
-# footprint and can be very valuable when troubleshooting a running container
+# footprint and can be very valuable when troubleshooting a running container,
 RUN apt-get update && apt-get install -y less jq strace
+# These packages allow for a better integration for some containers, for example
+# daemontools provides envdir, which is very convenient for passing backup
+# environment variables around.
+RUN apt-get update && apt-get install -y dumb-init daemontools
 
 RUN apt-get update \
     && apt-get install -y postgresql-common pgbackrest libpq-dev libpq5 \


### PR DESCRIPTION
To support a few use cases, it would be very handy to have some tools be
part of the Docker image. These are tiny (kB)'s, but open up some
further development avenues.

envdir

Having envdir availabe to use would allow us to remove some bash
scripting that we do to juggle around environment variables (PGBACKREST_
for example). It would also allow us to expose secrets via a ConfigMap
(instead of as environment variables to the container) and have envdir
only expose these environment variables to some scripts, again the
backup seems to be most likely to benifit.

dumb-init

https://github.com/Yelp/dumb-init
Some commands, if run as pid 1, do not respond to SIGTERM, which means
we cannot run a container that tail -f some logfile. The use case for
this is not fully panned out yet, however it could be that we want to
split up the logs from Patroni and of PostgreSQL. If we do that, we may
want to run a tail -f in a container for one of these logs; using
dumb-init would make this pattern possible.