### PR TITLE
Build PostgreSQL 12 images in CI/CD

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,8 +42,6 @@ variables:
   REGISTRY_SECRET_NAME: registry-key-savannah-timescaledb-docker-patroni
   # Using the default mirrors caused a lot of timeouts previously
   DEBIAN_REPO_MIRROR: cdn-aws.deb.debian.org
-  # By using the previously built image, we can build the images very quickly
-  DOCKER_IMAGE_CACHE: --cache-from registry.gitlab.com/timescale/timescaledb-docker-ha:builder-pg11
 
 before_script:
   # NOTE: these credentials are created by the GitlabCI system, and are ephemeral. They are only
@@ -51,32 +49,49 @@ before_script:
   - apk add make jq
   - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
 
-build.feature-branch:
+build.feature-branch-11: &build_feature-branch
   stage: build
   except: [ "master", "release", "tags" ]
   tags: [ "docker" ]
   variables:
+    PG_MAJOR: "11"
+    DOCKER_IMAGE_CACHE: --cache-from registry.gitlab.com/timescale/timescaledb-docker-ha:builder-pg11
   script:
-    - docker pull registry.gitlab.com/timescale/timescaledb-docker-ha:builder-pg11
+    - docker pull registry.gitlab.com/timescale/timescaledb-docker-ha:builder-pg${PG_MAJOR} || true
     - make push-builder
     - make test
     - make push
     - docker image ls
 
-build.master-branch:
+build.feature-branch-12:
+  << : *build_feature-branch
+  variables:
+    PG_MAJOR: "12"
+    DOCKER_IMAGE_CACHE: --cache-from registry.gitlab.com/timescale/timescaledb-docker-ha:builder-pg12
+
+build.master-branch-11: &build_master-branch
   stage: build
   only: [ "master" ]
   tags: [ "docker" ]
+  variables:
+    PG_MAJOR: "11"
   script:
     - make push-builder
     - make test
     - make push-all
     - docker image ls
 
-build.release:
+build.master-branch-12:
+  << : *build_master-branch
+  variables:
+    PG_MAJOR: "12"
+
+build.release-11: &build_release
   stage: build
   only: [ "tags" ]
   tags: [ "docker" ]
+  variables:
+    PG_MAJOR: "11"
   variables:
     TAG: ${CI_COMMIT_TAG}
     GIT_REV: ${CI_COMMIT_TAG}
@@ -84,3 +99,9 @@ build.release:
     - make test
     - make push-all
     - docker image ls
+
+build.release-12:
+  << : *build_release
+  variables:
+    PG_MAJOR: "12"
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 These are changes that will probably be included in the next release.
 
 ### Added
- * Support PostgreSQL 12
 ### Changed
 ### Removed
 ### Fixed
 
 ## [v0.2.10] - 2020-03-20
+
+### Added
+ * Support PostgreSQL 12
+ * Support for TimescaleDB 1.7 (PostgreSQL 11 & PostgreSQL 12)
+### Changed
+ * Build 2 sets of Docker images in CI/CD (PostgreSQL 11 & PostgreSQL 12)
 
 ### Added
  * Remove stale pidfile if it exists

--- a/Dockerfile
+++ b/Dockerfile
@@ -180,7 +180,7 @@ COPY --from=timescale/timescaledb:latest-pg11 /usr/local/bin/timescaledb-tune /u
 
 # timescaledb-tune does not support PostgreSQL 12 yet, however the (global) pg_config shipped by Debian
 # is PostgreSQL 12. Therefore we need to explicitly pass on the PostgreSQL version to timescaledb-tune
-RUN sed -i "s/timescaledb-tune/timescaledb-tune --pg-version=${PG_MAJOR}/g" /docker-entrypoint-initdb.d/*.sh
+RUN sed -i "s/timescaledb-tune/timescaledb-tune --pg-version=11/g" /docker-entrypoint-initdb.d/*.sh
 
 RUN ln -s /usr/local/bin/docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -72,12 +72,12 @@ build build-oss build-tag: builder
 	#
 	# We will then attach this information as OCI labels to the final Docker image
 	# https://github.com/opencontainers/image-spec/blob/master/annotations.md
-	docker stop dummy$(POSTFIX) || true
-	docker run -d --rm --name dummy$(POSTFIX) -e PGDATA=/tmp/pgdata --user=postgres $(TIMESCALEDB_RELEASE_URL)$(POSTFIX)-wip \
+	docker stop dummy$(PG_MAJOR)$(POSTFIX) || true
+	docker run -d --rm --name dummy$(PG_MAJOR)$(POSTFIX) -e PGDATA=/tmp/pgdata --user=postgres $(TIMESCALEDB_RELEASE_URL)$(POSTFIX)-wip \
 		sh -c 'initdb && timeout 30 postgres'
-	docker exec -i dummy$(POSTFIX) sh -c 'while ! pg_isready; do sleep 1; done'
-	cat scripts/version_info.sql | docker exec -i dummy$(POSTFIX) psql -AtXq | tee .$@
-	docker stop dummy$(POSTFIX)
+	docker exec -i dummy$(PG_MAJOR)$(POSTFIX) sh -c 'while ! pg_isready; do sleep 1; done'
+	cat scripts/version_info.sql | docker exec -i dummy$(PG_MAJOR)$(POSTFIX) psql -AtXq | tee .$@
+	docker stop dummy$(PG_MAJOR)$(POSTFIX)
 
 	# This is where we build the final Docker Image, including all the version labels
 	echo "FROM $(TIMESCALEDB_RELEASE_URL)$(POSTFIX)-wip" | docker build --tag $(TIMESCALEDB_RELEASE_URL)$(POSTFIX) - \


### PR DESCRIPTION
# Stamp v0.2.10

# Support for PG12
As TimescaleDB 1.7 has been released, we can now support PostgreSQL 12,
after this commit, Docker images for PostgreSQL 11 and PostgreSQL 12
will be built during CI/CD.

To avoid name clashes the dummy container names now also include the
major PostgreSQL version.