### PR TITLE
Backup improvements for restoring without a master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ These are changes that will probably be included in the next release.
 
 ### Added
 ### Changed
+ * Allow restore from backup even when no master is running
 ### Removed
 ### Fixed
+ * Backup parameters
 
 ## [v0.2.10] - 2020-04-20
 

--- a/scripts/augment_patroni_configuration.py
+++ b/scripts/augment_patroni_configuration.py
@@ -22,13 +22,14 @@ postgresql:
     command: '/usr/bin/pgbackrest --stanza=poddb --delta restore --log-level-stderr=info'
     keep_data: True
     no_params: True
+    no_master: 1
 bootstrap:
   dcs:
     postgresql:
       recovery_conf:
         recovery_target_timeline: latest
         standby_mode: 'on'
-        restore_command: 'pgbackrest --stanza=demo archive-get %f "%p"'
+        restore_command: 'pgbackrest --stanza=poddb archive-get %f "%p"'
 """
 
 

--- a/scripts/post_init.sh
+++ b/scripts/post_init.sh
@@ -20,7 +20,7 @@ __SQL__
 
 log "Waiting for pgBackRest API to become responsive"
 while sleep 1; do
-    if [ $SECONDS -gt 10 ]; then
+    if [ $SECONDS -gt 30 ]; then
         log "pgBackRest API did not respond within $SECONDS seconds, will not trigger a backup"
         exit 0
     fi


### PR DESCRIPTION
By default, Patroni will not restore a backup if no master can be found.
However, it may be a totally valid usecase to pause your deployment.

Therefore, we will allow bootstrapping to be done using the backup even
if no master is currently running.

Second, the race between the pgBackRest wrapper and initdb seemed to
have been a bit to tight, so allow 30 seconds instead of 10 seconds to
pass before bailing out on triggering a backup.

Third, a misconfiguration, as --stanza=demo never existed. As the
command was only used in the thus far never supported mode of bootstrap
without master, it never was an issue.