### PR TITLE
Remove support for TimescaleDB < 1.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ ARG INSTALL_METHOD=docker-ha
 # If a specific GITHUB_TAG is provided, we will build that tag only. Otherwise
 # we build all the public (recent) releases
 RUN TS_VERSIONS=$(curl "https://api.github.com/repos/${GITHUB_REPO}/releases" \
-        | jq -r '.[] | select(.draft == false) | select(.created_at > "2018-12-13") | .tag_name' | sort -V) \
+        | jq -r '.[] | select(.draft == false) | select(.created_at > "2020-01-01") | .tag_name' | sort -V) \
     && if [ "${GITHUB_TAG}" != "" ]; then TS_VERSIONS="${GITHUB_TAG}"; fi \
     && set -e \
     && for pg in ${PG_VERSIONS}; do \


### PR DESCRIPTION
This reduces the build time considerably, especially if installchecks
are enabled.