### PR TITLE
Enable installcheck when releasing the Docker Images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,6 +93,7 @@ build.release-11: &build_release
   variables:
     PG_MAJOR: "11"
   variables:
+    ENABLE_INSTALL_CHECK: "1"
     TAG: ${CI_COMMIT_TAG}
     GIT_REV: ${CI_COMMIT_TAG}
   script:

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ PUBLISH_REPOSITORY?=docker.io/timescaledev/timescaledb-ha
 BUILDARGS=
 POSTFIX=
 INSTALL_METHOD?=docker-ha
+ENABLE_INSTALL_CHECK?=0
 
 build-oss:     POSTFIX   = -oss
 build-oss:	   BUILDARGS = --build-arg OSS_ONLY=" -DAPACHE_ONLY=1"
@@ -56,6 +57,7 @@ DOCKER_BUILD_COMMAND=docker build --build-arg PG_MAJOR=$(PG_MAJOR) \
 					 --build-arg TIMESCALE_PROMETHEUS=$(TIMESCALE_PROMETHEUS) \
 					 --build-arg POSTGIS_VERSIONS=$(POSTGIS_VERSIONS) \
 					 --build-arg DEBIAN_REPO_MIRROR=$(DEBIAN_REPO_MIRROR) $(DOCKER_IMAGE_CACHE) \
+					 --build-arg ENABLE_INSTALL_CHECK=$(ENABLE_INSTALL_CHECK) \
 					 --build-arg PG_VERSIONS="$(PG_VERSIONS)" \
 					 --label org.opencontainers.image.created="$$(date -Iseconds --utc)" \
 					 --label org.opencontainers.image.revision="$(GIT_REV)" \


### PR DESCRIPTION
by running the installcheck during build, we verify that what we've
installed passes some tests. This means we can trust the result more
than if we hadn't run the tests.