### PR TITLE
build tsdb_admin, tsdb_prometheus, and publish images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,10 +22,12 @@ services:
 # `script` keyword). Pipelines are formed by creating jobs which are executed as part
 # of specific stages.
 stages:
+  - builder
   - build
   - tests.system
   - tests.load
   - release
+  - publish
 
 variables:
   # Use an allegedly faster FS option for docker builds.
@@ -53,32 +55,48 @@ before_script:
   - apk add make jq
   - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
 
-build.feature-branch-11: &build_feature-branch
+# The builder Docker image is only built from scratch if we tag a release. This ensures
+# most pipelines (master, PR's) are going to be fast, as they use a stale builder Docker image,
+# however for the release we really want to ensure we get the latest greatest, so we run this
+# one first
+builder:
+  only: [ "tags" ]
+  stage: builder
+  script:
+  - true || PG_MAJOR=11 make push-builder
+  - true || PG_MAJOR=12 make push-builder
+
+
+.build.feature-branch:
   stage: build
-  except: [ "master", "release", "tags" ]
   tags: [ "docker" ]
   variables:
-    PG_MAJOR: "11"
-    DOCKER_IMAGE_CACHE: --cache-from registry.gitlab.com/timescale/timescaledb-docker-ha:builder-pg11
+    PG_MAJOR: "12"
+    DOCKER_IMAGE_CACHE: registry.gitlab.com/timescale/timescaledb-docker-ha:builder-pg12
   script:
-    - docker pull registry.gitlab.com/timescale/timescaledb-docker-ha:builder-pg${PG_MAJOR} || true
-    - make push-builder
+    - docker pull ${DOCKER_IMAGE_CACHE} || true
     - make test
     - make push
     - docker image ls
 
 build.feature-branch-12:
-  << : *build_feature-branch
+  extends: .build.feature-branch
   variables:
     PG_MAJOR: "12"
-    DOCKER_IMAGE_CACHE: --cache-from registry.gitlab.com/timescale/timescaledb-docker-ha:builder-pg12
+    DOCKER_IMAGE_CACHE: registry.gitlab.com/timescale/timescaledb-docker-ha:builder-pg12
 
-build.master-branch-11: &build_master-branch
+build.feature-branch-11:
+  extends: .build.feature-branch
+  variables:
+    PG_MAJOR: "11"
+    DOCKER_IMAGE_CACHE: registry.gitlab.com/timescale/timescaledb-docker-ha:builder-pg11
+
+.build.master-branch:
   stage: build
   only: [ "master" ]
   tags: [ "docker" ]
   variables:
-    PG_MAJOR: "11"
+    PG_MAJOR: "12"
   script:
     - make push-builder
     - make test
@@ -86,26 +104,44 @@ build.master-branch-11: &build_master-branch
     - docker image ls
 
 build.master-branch-12:
-  << : *build_master-branch
+  extends: .build.master-branch
   variables:
     PG_MAJOR: "12"
 
-build.release-11: &build_release
-  stage: build
-  only: [ "tags" ]
-  tags: [ "docker" ]
+build.master-branch-11:
+  extends: .build.master-branch
   variables:
     PG_MAJOR: "11"
-  variables:
-    TAG: ${CI_COMMIT_TAG}
-    GIT_REV: ${CI_COMMIT_TAG}
-  script:
-    - make test
-    - make push-all
-    - docker image ls
 
-build.release-12:
-  << : *build_release
+.publish.release:
+  only: [ "tags" ]
+  tags: [ "docker" ]
+  stage: publish
   variables:
     PG_MAJOR: "12"
+    DOCKER_IMAGE_CACHE: debian:buster-slim
+    TAG: ${CI_COMMIT_TAG}
+    GIT_REV: ${CI_COMMIT_TAG}
+    RELEASE_TAG: ${CI_COMMIT_TAG}
+  script:
+    # We only want to publish if the tag starts with v, other tags should not publish
+    - '[ "${TAG#\v}x" == "${TAG}x" ] && exit 0'
+    - docker login -u $DH_REGISTRY_USER -p $DH_REGISTRY_PASSWORD $DH_REGISTRY
+    - docker pull registry.gitlab.com/timescale/timescaledb-docker-ha:builder-pg${PG_MAJOR} || true
+    - make test
+    - make push-all
+    - make publish
+    - make publish-oss
+    - docker image ls
 
+publish.release-12:
+  extends: .publish.release
+  variables:
+    PG_MAJOR: "12"
+    DOCKER_IMAGE_CACHE: registry.gitlab.com/timescale/timescaledb-docker-ha:builder-pg12
+
+publish.release-11:
+  extends: .publish.release
+  variables:
+    PG_MAJOR: "11"
+    DOCKER_IMAGE_CACHE: registry.gitlab.com/timescale/timescaledb-docker-ha:builder-pg11

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,10 @@ variables:
   REGISTRY_SECRET_NAME: registry-key-savannah-timescaledb-docker-patroni
   # Using the default mirrors caused a lot of timeouts previously
   DEBIAN_REPO_MIRROR: cdn-aws.deb.debian.org
+  #
+  CUSTOM_INSTALL_METHOD: ${CUSTOM_INSTALL_METHOD}
+  TIMESCALE_TSDB_ADMIN: 0.1.0-alpha.1
+  TIMESCALE_PROMETHEUS: 0.1.0-alpha.4
 
 before_script:
   # NOTE: these credentials are created by the GitlabCI system, and are ephemeral. They are only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ These are changes that will probably be included in the next release.
  * `tsdb_admin` can be included in the image
  * `timescale_prometheus` is now included in the image
 ### Changed
+ * GitLab CI/CD will now publish Docker images to Docker hub on version tags
 ### Removed
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ These are changes that will probably be included in the next release.
  * Include custom timescaledb scripts for pgextwlist
  * `lz4` support, which can be used by pgBackRest
  * `tsdb_admin` can be included in the image
+ * `timescale_prometheus` is now included in the image
 ### Changed
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ These are changes that will probably be included in the next release.
  * Include `psutils` to allow some process troubleshooting inside the container
  * Include custom timescaledb scripts for pgextwlist
  * `lz4` support, which can be used by pgBackRest
+ * `tsdb_admin` can be included in the image
 ### Changed
 ### Removed
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -168,6 +168,21 @@ RUN if [ ! -z "${TIMESCALE_PROMETHEUS}" ]; then \
         done; \
     fi
 
+# Protected Roles is a library that restricts the CREATEROLE/CREATEDB privileges of non-superusers.
+# It is a private timescale project and is therefore not included/built by default
+ARG TIMESCALE_TSDB_ADMIN=
+ARG CI_JOB_TOKEN=
+RUN if [ ! -z "${CI_JOB_TOKEN}" ]; then \
+        if [ ! -z "${TIMESCALE_TSDB_ADMIN}" ]; then \
+            cd /build \
+            && git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.com/timescale/protected_roles \
+            && for pg in ${PG_VERSIONS}; do \
+                cd /build/protected_roles && git reset HEAD --hard && git checkout ${TIMESCALE_TSDB_ADMIN} \
+                && make clean && PG_CONFIG=/usr/lib/postgresql/${pg}/bin/pg_config make install || exit 1 ; \
+            done; \
+        fi; \
+    fi
+
 ## Cleanup
 RUN apt-get remove -y ${BUILD_PACKAGES}
 RUN apt-get autoremove -y \

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ GITHUB_TOKEN?=""
 GITHUB_REPO?="timescale/timescaledb"
 GITHUB_TAG?="master"
 
+# This variable is set when running in gitlab CI/CD, and allows us to clone
+# private repositories.
+CI_JOB_TOKEN?=""
+
 TAG?=$(subst /,_,$(GIT_BRANCH)-$(GIT_COMMIT))
 REGISTRY?=localhost:5000
 TIMESCALEDB_REPOSITORY?=timescale/timescaledb-docker-ha
@@ -31,6 +35,7 @@ TIMESCALEDB_RELEASE_URL?=$(TIMESCALEDB_IMAGE):$(TAG)-$(PGVERSION)
 TIMESCALEDB_LATEST_URL?=$(TIMESCALEDB_IMAGE):latest-$(PGVERSION)
 PG_PROMETHEUS?=
 TIMESCALE_PROMETHEUS?=master
+TIMESCALE_TSDB_ADMIN?=
 
 CICD_REPOSITORY?=registry.gitlab.com/timescale/timescaledb-docker-ha
 PUBLISH_REPOSITORY?=docker.io/timescaledev/timescaledb-ha
@@ -51,12 +56,14 @@ build-tag: 	   BUILDARGS = --build-arg GITHUB_REPO=$(GITHUB_REPO) --build-arg GI
 # for all the version information. In that way, we are sure we never tag the Docker images with the wrong
 # versions.
 # I'm using $$(jq) instead of $(shell), as we need to evaluate these variables for every new image build
-DOCKER_BUILD_COMMAND=docker build --build-arg PG_MAJOR=$(PG_MAJOR) \
+DOCKER_BUILD_COMMAND=docker build  \
 					 --build-arg PG_PROMETHEUS=$(PG_PROMETHEUS) \
 					 --build-arg TIMESCALE_PROMETHEUS=$(TIMESCALE_PROMETHEUS) \
 					 --build-arg POSTGIS_VERSIONS=$(POSTGIS_VERSIONS) \
 					 --build-arg DEBIAN_REPO_MIRROR=$(DEBIAN_REPO_MIRROR) $(DOCKER_IMAGE_CACHE) \
 					 --build-arg PG_VERSIONS="$(PG_VERSIONS)" \
+					 --build-arg TIMESCALE_TSDB_ADMIN="$(TIMESCALE_TSDB_ADMIN)" \
+					 --build-arg CI_JOB_TOKEN="$(CI_JOB_TOKEN)" \
 					 --label org.opencontainers.image.created="$$(date -Iseconds --utc)" \
 					 --label org.opencontainers.image.revision="$(GIT_REV)" \
 					 --label org.opencontainers.image.vendor=Timescale \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
-PG_MAJOR?=11
+PG_MAJOR?=12
 # All PG_VERSIONS binaries/libraries will be included in the Dockerfile
 # specifying multiple versions will allow things like pg_upgrade etc to work.
 PG_VERSIONS?=12 11
-PGVERSION=pg$(PG_MAJOR)
 POSTGIS_VERSIONS?="2.5 3"
 
 # CI/CD can benefit from specifying a specific apt packages mirror
@@ -30,9 +29,9 @@ TAG?=$(subst /,_,$(GIT_BRANCH)-$(GIT_COMMIT))
 REGISTRY?=localhost:5000
 TIMESCALEDB_REPOSITORY?=timescale/timescaledb-docker-ha
 TIMESCALEDB_IMAGE?=$(REGISTRY)/$(TIMESCALEDB_REPOSITORY)
-TIMESCALEDB_BUILDER_URL?=$(TIMESCALEDB_IMAGE):builder-$(PGVERSION)
-TIMESCALEDB_RELEASE_URL?=$(TIMESCALEDB_IMAGE):$(TAG)-$(PGVERSION)
-TIMESCALEDB_LATEST_URL?=$(TIMESCALEDB_IMAGE):latest-$(PGVERSION)
+TIMESCALEDB_BUILDER_URL?=$(TIMESCALEDB_IMAGE):builder
+TIMESCALEDB_RELEASE_URL?=$(TIMESCALEDB_IMAGE):$(TAG)
+TIMESCALEDB_LATEST_URL?=$(TIMESCALEDB_IMAGE):latest
 PG_PROMETHEUS?=
 TIMESCALE_PROMETHEUS?=0.1.0-alpha.4
 TIMESCALE_TSDB_ADMIN?=
@@ -43,7 +42,12 @@ PUBLISH_REPOSITORY?=docker.io/timescaledev/timescaledb-ha
 BUILDARGS=
 POSTFIX=
 INSTALL_METHOD?=docker-ha
+DOCKER_IMAGE_CACHE?=$(TIMESCALEDB_BUILDER_URL)-pg$(PG_MAJOR)
 
+builder-11:    PG_MAJOR  = 11
+builder-12:    PG_MAJOR  = 12
+build-all-11:  PG_MAJOR  = 11
+build-all-12:  PG_MAJOR  = 12
 build-oss:     POSTFIX   = -oss
 build-oss:	   BUILDARGS = --build-arg OSS_ONLY=" -DAPACHE_ONLY=1"
 build-tag: 	   POSTFIX   = -$(GITHUB_TAG)
@@ -60,10 +64,11 @@ DOCKER_BUILD_COMMAND=docker build  \
 					 --build-arg PG_PROMETHEUS=$(PG_PROMETHEUS) \
 					 --build-arg TIMESCALE_PROMETHEUS=$(TIMESCALE_PROMETHEUS) \
 					 --build-arg POSTGIS_VERSIONS=$(POSTGIS_VERSIONS) \
-					 --build-arg DEBIAN_REPO_MIRROR=$(DEBIAN_REPO_MIRROR) $(DOCKER_IMAGE_CACHE) \
+					 --build-arg DEBIAN_REPO_MIRROR=$(DEBIAN_REPO_MIRROR) \
 					 --build-arg PG_VERSIONS="$(PG_VERSIONS)" \
 					 --build-arg TIMESCALE_TSDB_ADMIN="$(TIMESCALE_TSDB_ADMIN)" \
 					 --build-arg CI_JOB_TOKEN="$(CI_JOB_TOKEN)" \
+					 --cache-from $(DOCKER_IMAGE_CACHE) \
 					 --label org.opencontainers.image.created="$$(date -Iseconds --utc)" \
 					 --label org.opencontainers.image.revision="$(GIT_REV)" \
 					 --label org.opencontainers.image.vendor=Timescale \
@@ -73,8 +78,7 @@ default: build
 
 .PHONY: build build-oss build-tag
 build build-oss build-tag: builder
-	$(DOCKER_BUILD_COMMAND) --tag $(TIMESCALEDB_RELEASE_URL)$(POSTFIX)-wip --build-arg INSTALL_METHOD="$(INSTALL_METHOD)" $(BUILDARGS) .
-
+	$(DOCKER_BUILD_COMMAND) --tag $(TIMESCALEDB_RELEASE_URL)-pg$(PG_MAJOR)$(POSTFIX)-wip --build-arg INSTALL_METHOD="$(INSTALL_METHOD)" --build-arg PG_MAJOR=$(PG_MAJOR) $(BUILDARGS) .
 	# In these steps we do some introspection to find out some details of the versions
 	# that are inside the Docker image. As we use the Debian packages, we do not know until
 	# after we have built the image, what patch version of PostgreSQL, or PostGIS is installed.
@@ -82,7 +86,7 @@ build build-oss build-tag: builder
 	# We will then attach this information as OCI labels to the final Docker image
 	# https://github.com/opencontainers/image-spec/blob/master/annotations.md
 	docker stop dummy$(PG_MAJOR)$(POSTFIX) || true
-	docker run -d --rm --name dummy$(PG_MAJOR)$(POSTFIX) -e PGDATA=/tmp/pgdata --user=postgres $(TIMESCALEDB_RELEASE_URL)$(POSTFIX)-wip \
+	docker run -d --rm --name dummy$(PG_MAJOR)$(POSTFIX) -e PGDATA=/tmp/pgdata --user=postgres $(TIMESCALEDB_RELEASE_URL)-pg$(PG_MAJOR)$(POSTFIX)-wip \
 		sh -c 'initdb && timeout 30 postgres'
 	docker exec -i dummy$(PG_MAJOR)$(POSTFIX) sh -c 'while ! pg_isready; do sleep 1; done'
 	cat scripts/version_info.sql | docker exec -i dummy$(PG_MAJOR)$(POSTFIX) psql -AtXq | tee .$@
@@ -95,27 +99,31 @@ build build-oss build-tag: builder
 	echo "FROM $(TIMESCALEDB_RELEASE_URL)-pg$(PG_MAJOR)$(POSTFIX)-wip" | docker build --tag $(TIMESCALEDB_RELEASE_URL)-pg$(PG_MAJOR)$(POSTFIX) - \
 		$$(awk -F '=' '{printf "--label com.timescaledb.image."$$1".version="$$2" "}' .$@) --label com.timescaledb.image.install_method=$(INSTALL_METHOD)
 
-	docker tag $(TIMESCALEDB_RELEASE_URL)$(POSTFIX) $(TIMESCALEDB_LATEST_URL)$(POSTFIX)
+	docker tag $(TIMESCALEDB_RELEASE_URL)-pg$(PG_MAJOR)$(POSTFIX) $(TIMESCALEDB_LATEST_URL)-pg$(PG_MAJOR)$(POSTFIX)
 
 .PHONY: build-all
-build-all: build build-oss
+build-all:
+	$(MAKE) build-all-$(PG_MAJOR)
 
-# To speed up most builds, having .builder be an actual target is very useful
-.builder: Dockerfile $(shell find . -type f ! -path '*.git*' ! -name '*build*')
-	$(DOCKER_BUILD_COMMAND) --target builder -t $(TIMESCALEDB_BUILDER_URL) $(BUILDARGS) .
-	touch .builder
-.PHONY: builder
-builder: .builder
+.PHONY: build-all-11 build-all-12
+build-all-11 build-all-12: build build-oss
+
+.PHONY: builder builder-11 builder-12
+builder-11 builder-12:
+	$(DOCKER_BUILD_COMMAND) --target builder -t $(TIMESCALEDB_BUILDER_URL)-pg$(PG_MAJOR) --build-arg PG_MAJOR=$(PG_MAJOR) $(BUILDARGS) .
+
+builder:
+	$(MAKE) builder-$(PG_MAJOR)
 
 .PHONY: push-builder
-push-builder: .builder
-	docker push $(TIMESCALEDB_BUILDER_URL)
+push-builder: builder
+	docker push $(TIMESCALEDB_BUILDER_URL)-pg$(PG_MAJOR)
 
 .PHONY: push push-oss
 push push-oss: push% : build%
 	export POSTFIX=$$(echo $@ | cut -c 5-) \
-	&& docker push $(TIMESCALEDB_RELEASE_URL)$${POSTFIX} \
-	&& docker push $(TIMESCALEDB_LATEST_URL)$${POSTFIX}
+	&& docker push $(TIMESCALEDB_RELEASE_URL)-pg$(PG_MAJOR)$${POSTFIX} \
+	&& docker push $(TIMESCALEDB_LATEST_URL)-pg$(PG_MAJOR)$${POSTFIX}
 
 .PHONY: push-all
 push-all: push push-oss
@@ -169,7 +177,7 @@ test: build
 	#
 	# TODO: Create a good test-suite. For now, it's nice to have this target in CI/CD,
 	# and have it do something worthwhile
-	docker run --rm --tty $(TIMESCALEDB_RELEASE_URL) /bin/bash -c "initdb -D test && grep timescaledb test/postgresql.conf"
+	docker run --rm --tty $(TIMESCALEDB_RELEASE_URL)-pg$(PG_MAJOR) /bin/bash -c "initdb -D test && grep timescaledb test/postgresql.conf"
 
 clean:
 	rm -f .builder

--- a/README.md
+++ b/README.md
@@ -69,20 +69,18 @@ to apply or backport fixes. Patch releases will be based on tagged commits on th
 Major and minor releases should tag commits in the `master` branch. Patch releases should tag commits in a release branch.
 
 ## Publish the images to Docker Hub
-Publishing images to Docker Hub currently requires the following:
+Docker Images will be automatically published to Docker Hub for git tags starting with a `v`.
 
-- pull the images from GitLab
-- add annotations about versions
-- pushes the images to Docker Hub
+They will be written under quite a few aliases, for example, for PostgreSQL 12.3 and Timescale 1.7.1, the following images will be built and pushed/overwritten:
 
-We may at some point automate this further, for now there is a Makefile target that does this for you.
-To publish, you need to point to a tagged release that was successfully built by GitLab CI/CD.
+- timescaledev/timescaledb-ha:pg12
+- timescaledev/timescaledb-ha:pg12-ts1.7
+- timescaledev/timescaledb-ha:pg12.3-ts1.7
 
-> NOTE: You need to be logged in to docker hub as well as gitlab registry for this Makefile target to succeed
+The following image will only be pushed if it does not yet exist, this tag is immutable and is therefore the best candidate
+for production deployments:
 
-```console
-RELEASE_TAG=v0.2.9 make publish-all
-```
+- timescaledev/timescaledb-ha:pg12.3-ts1.7.1
 
 ## Patch process
 

--- a/scripts/version_info.sql
+++ b/scripts/version_info.sql
@@ -25,11 +25,6 @@ WITH versions(name, version) AS (
         :'pgbackrest'
 )
 SELECT
-    jsonb_pretty(
-        jsonb_object_agg(
-            name,
-            version
-        )
-    )
+    format('%s=%s', name, version)
 FROM
     versions;


### PR DESCRIPTION
# Refactoring of build process

- Introduce a few more ci/cd stages, so we can better control the
  pipeline in GitLab.
- Ensure we can push to the docker.io registry for those images that
  are to be published.
- Publish images when tag starts with a v, this removes the need to
  manually create images.
- Drop the use of yaml anchors in favor of GitLab `extends`
- Default to PostgreSQL 12 instead of PostgreSQL 11

# Include timescaledb_prometheus if specified

Some refactoring of the method of adding Docker Labels to the image, to
ensure every image has version information of the critical pieces it
contains.

# Include tsdb_admin if specified

tsdb_admin allows us to restrict the scope of CREATEROLE/CREATEDB users.
It needs to be explicitly configured in the shared_preload_libraries
before it will be used, adding this therefore does not intervene with
any existing deployments.
