### PR TITLE
Feike/rename tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -129,6 +129,7 @@ build.master-branch-11:
     - docker login -u $DH_REGISTRY_USER -p $DH_REGISTRY_PASSWORD $DH_REGISTRY
     - docker pull registry.gitlab.com/timescale/timescaledb-docker-ha:builder-pg${PG_MAJOR} || true
     - make test
+    - make test-oss
     - make push-all
     - make publish
     - make publish-oss

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,7 +46,7 @@ variables:
   DEBIAN_REPO_MIRROR: cdn-aws.deb.debian.org
   #
   CUSTOM_INSTALL_METHOD: ${CUSTOM_INSTALL_METHOD}
-  TIMESCALE_TSDB_ADMIN: 0.1.0-alpha.1
+  TIMESCALE_TSDB_ADMIN: 0.1.0
   TIMESCALE_PROMETHEUS: 0.1.0-alpha.4
 
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.2.15] - 2020-06-26
 
-These are changes that will probably be included in the next release.
-
-### Added
 ### Changed
-### Removed
+ * Docker Image tag names, all images which are mutable are postfixed with `-latest`
+
+## [v0.2.14] - 2020-06-24
+
+### Fixed
+ * Ensure builder is built for every new tagged release
 
 ## [v0.2.13] - 2020-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.2.15] - 2020-06-26
+## [v0.2.15] - 2020-06-30
 
 ### Changed
  * Docker Image tag names, all images which are mutable are postfixed with `-latest`

--- a/Dockerfile
+++ b/Dockerfile
@@ -172,15 +172,13 @@ RUN if [ ! -z "${TIMESCALE_PROMETHEUS}" ]; then \
 # It is a private timescale project and is therefore not included/built by default
 ARG TIMESCALE_TSDB_ADMIN=
 ARG CI_JOB_TOKEN=
-RUN if [ ! -z "${CI_JOB_TOKEN}" ]; then \
-        if [ ! -z "${TIMESCALE_TSDB_ADMIN}" ]; then \
-            cd /build \
-            && git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.com/timescale/protected_roles \
-            && for pg in ${PG_VERSIONS}; do \
-                cd /build/protected_roles && git reset HEAD --hard && git checkout ${TIMESCALE_TSDB_ADMIN} \
-                && make clean && PG_CONFIG=/usr/lib/postgresql/${pg}/bin/pg_config make install || exit 1 ; \
-            done; \
-        fi; \
+RUN if [ ! -z "${CI_JOB_TOKEN}" -a -z "${OSS_ONLY}" -a ! -z "${TIMESCALE_TSDB_ADMIN}" ]; then \
+        cd /build \
+        && git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.com/timescale/protected_roles \
+        && for pg in ${PG_VERSIONS}; do \
+            cd /build/protected_roles && git reset HEAD --hard && git checkout ${TIMESCALE_TSDB_ADMIN} \
+            && make clean && PG_CONFIG=/usr/lib/postgresql/${pg}/bin/pg_config make install || exit 1 ; \
+        done; \
     fi
 
 ## Cleanup

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,11 @@ PG_PROMETHEUS?=
 TIMESCALE_PROMETHEUS?=0.1.0-alpha.4
 TIMESCALE_TSDB_ADMIN?=
 
+IMMUTABLE_TAG=$(PUBLISH_REPOSITORY):$(RELEASE_TAG)$(POSTFIX)
+CICDIMAGE=$(CICD_REPOSITORY):$(RELEASE_TAG)-pg$(PG_MAJOR)$(POSTFIX)
+WIPTAG=$(TIMESCALEDB_RELEASE_URL)-pg$(PG_MAJOR)$(POSTFIX)-wip
+
+
 CICD_REPOSITORY?=registry.gitlab.com/timescale/timescaledb-docker-ha
 PUBLISH_REPOSITORY?=docker.io/timescaledev/timescaledb-ha
 
@@ -78,7 +83,7 @@ default: build
 
 .PHONY: build build-oss build-tag
 build build-oss build-tag: builder
-	$(DOCKER_BUILD_COMMAND) --tag $(TIMESCALEDB_RELEASE_URL)-pg$(PG_MAJOR)$(POSTFIX)-wip --build-arg INSTALL_METHOD="$(INSTALL_METHOD)" --build-arg PG_MAJOR=$(PG_MAJOR) $(BUILDARGS) .
+	$(DOCKER_BUILD_COMMAND) --tag $(WIPTAG) --build-arg INSTALL_METHOD="$(INSTALL_METHOD)" --build-arg PG_MAJOR=$(PG_MAJOR) $(BUILDARGS) .
 	# In these steps we do some introspection to find out some details of the versions
 	# that are inside the Docker image. As we use the Debian packages, we do not know until
 	# after we have built the image, what patch version of PostgreSQL, or PostGIS is installed.
@@ -86,7 +91,7 @@ build build-oss build-tag: builder
 	# We will then attach this information as OCI labels to the final Docker image
 	# https://github.com/opencontainers/image-spec/blob/master/annotations.md
 	docker stop dummy$(PG_MAJOR)$(POSTFIX) || true
-	docker run -d --rm --name dummy$(PG_MAJOR)$(POSTFIX) -e PGDATA=/tmp/pgdata --user=postgres $(TIMESCALEDB_RELEASE_URL)-pg$(PG_MAJOR)$(POSTFIX)-wip \
+	docker run -d --rm --name dummy$(PG_MAJOR)$(POSTFIX) -e PGDATA=/tmp/pgdata --user=postgres $(WIPTAG) \
 		sh -c 'initdb && timeout 30 postgres'
 	docker exec -i dummy$(PG_MAJOR)$(POSTFIX) sh -c 'while ! pg_isready; do sleep 1; done'
 	cat scripts/version_info.sql | docker exec -i dummy$(PG_MAJOR)$(POSTFIX) psql -AtXq | tee .$@
@@ -96,7 +101,7 @@ build build-oss build-tag: builder
 	[ -z "$(TIMESCALE_PROMETHEUS)" ] || echo "timescale_prometheus=$(TIMESCALE_PROMETHEUS)" >> .$@
 
 	# This is where we build the final Docker Image, including all the version labels
-	echo "FROM $(TIMESCALEDB_RELEASE_URL)-pg$(PG_MAJOR)$(POSTFIX)-wip" | docker build --tag $(TIMESCALEDB_RELEASE_URL)-pg$(PG_MAJOR)$(POSTFIX) - \
+	echo "FROM $(WIPTAG)" | docker build --tag $(TIMESCALEDB_RELEASE_URL)-pg$(PG_MAJOR)$(POSTFIX) - \
 		$$(awk -F '=' '{printf "--label com.timescaledb.image."$$1".version="$$2" "}' .$@) --label com.timescaledb.image.install_method=$(INSTALL_METHOD)
 
 	docker tag $(TIMESCALEDB_RELEASE_URL)-pg$(PG_MAJOR)$(POSTFIX) $(TIMESCALEDB_LATEST_URL)-pg$(PG_MAJOR)$(POSTFIX)
@@ -131,30 +136,29 @@ push-all: push push-oss
 # The purpose of publishing the images under many tags, is to provide
 # some choice to the user as to their appetite for volatility.
 #
-#  1. timescaledev/timescaledb-ha:pg11
-#  2. timescaledev/timescaledb-ha:pg11-ts1.6
-#  3. timescaledev/timescaledb-ha:pg11.7-ts1.6
-#  4. timescaledev/timescaledb-ha:pg11.7-ts1.6.0
+#  1. timescaledev/timescaledb-ha:pg12-latest
+#  2. timescaledev/timescaledb-ha:pg12-ts1.7-latest
+#  3. timescaledev/timescaledb-ha:pg12.3-ts1.7-latest
+#  4. timescaledev/timescaledb-ha:pg12.3-ts1.7.1-latest
+#  5. timescaledev/timescaledb-ha:v0.2.15
 #
-# Tag 4 is immutable, and we will only push that one iff it does not yet exist.
-# 4. would therefore be most suitable for production environments
+# Tag 5 is immutable, and we will only push that one iff it does not yet exist.
+# 5. would therefore be most suitable for production environments. This tag is only
+# created for the latest PostgreSQL version.
 .PHONY: publish publish-oss
 publish publish-oss:
-	export POSTFIX=$$(echo $@ | cut -c 8-) \
-	&& export CICDIMAGE="$(CICD_REPOSITORY):$(RELEASE_TAG)-pg$(PG_MAJOR)$${POSTFIX}" \
-	&& docker pull $${CICDIMAGE} \
-	&& export PGVERSION=$$(docker inspect $${CICDIMAGE} | jq '.[0]."ContainerConfig"."Labels"."com.timescaledb.image.postgresql.version"' -r) \
-	&& export TSPATCH=$$(docker inspect $${CICDIMAGE} | jq '.[0]."ContainerConfig"."Labels"."com.timescaledb.image.timescaledb.version"' -r) \
+	export PGVERSION=$$(docker inspect $(CICDIMAGE) | jq '.[0]."ContainerConfig"."Labels"."com.timescaledb.image.postgresql.version"' -r) \
+	&& export TSPATCH=$$(docker inspect $(CICDIMAGE) | jq '.[0]."ContainerConfig"."Labels"."com.timescaledb.image.timescaledb.version"' -r) \
 	&& export TSMINOR=$${TSPATCH%.*} \
-	&& for variant in pg$(PG_MAJOR)$${POSTFIX} pg$(PG_MAJOR)-ts$${TSMINOR}$${POSTFIX} pg$${PGVERSION}-ts$${TSMINOR}$${POSTFIX}; \
+	&& for variant in pg$(PG_MAJOR)$${POSTFIX}-latest pg$(PG_MAJOR)-ts$${TSMINOR}$${POSTFIX}-latest pg$${PGVERSION}-ts$${TSMINOR}$${POSTFIX}-latest pg$${PGVERSION}-ts$${TSPATCH}$${POSTFIX}-latest; \
 		do \
-			docker tag $${CICDIMAGE} $(PUBLISH_REPOSITORY):$${variant} \
+			docker tag $(CICDIMAGE) $(PUBLISH_REPOSITORY):$${variant} \
 			&& docker push $(PUBLISH_REPOSITORY):$${variant} || exit 1; \
 		done \
-	&& export variant=pg$${PGVERSION}-ts$${TSPATCH}$${POSTFIX} \
-	&& docker tag $${CICDIMAGE} $(PUBLISH_REPOSITORY):$${variant} \
-	&& docker pull $(PUBLISH_REPOSITORY):$${variant} > /dev/null && echo "Not pushing $(PUBLISH_REPOSITORY):$${variant} as it already exists" \
-	   || docker push $(PUBLISH_REPOSITORY):$${variant}
+	&& if test $(PG_MAJOR) -eq 12; then \
+		docker tag $(CICDIMAGE) $(IMMUTABLE_TAG) \
+		&& docker pull $(IMMUTABLE_TAG) &> /dev/null && echo "Not pushing $(IMMUTABLE_TAG) as it already exists" || docker push $(IMMUTABLE_TAG) || exit 1; \
+	   fi
 
 .PHONY: publish
 publish-all:
@@ -169,7 +173,7 @@ endif
 	$(MAKE) publish publish-oss
 
 .PHONY: test
-test: build
+test test-oss: test%: build%
 	# Very simple test that verifies the following things:
 	# - PATH has the correct setting
 	# - initdb succeeds
@@ -178,6 +182,7 @@ test: build
 	# TODO: Create a good test-suite. For now, it's nice to have this target in CI/CD,
 	# and have it do something worthwhile
 	docker run --rm --tty $(TIMESCALEDB_RELEASE_URL)-pg$(PG_MAJOR) /bin/bash -c "initdb -D test && grep timescaledb test/postgresql.conf"
+	docker run --rm --tty $(TIMESCALEDB_RELEASE_URL)-pg$(PG_MAJOR)-oss /bin/bash -c "initdb -D test && grep timescaledb test/postgresql.conf"
 
 clean:
 	rm -f .builder


### PR DESCRIPTION
# Upgrade tsdb_admin

# Publish Docker Image under different tags

After some discussion, we decided to only publish mutable images with
the `latest` postfix, as this clearly communicates that the tag is
immutable.

Together with that, we also publish 1 immutable tag for every git tag in
our repository.
