### PR TITLE
Add grants to internal timescale schemas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .build*
+.idea/


### PR DESCRIPTION
To enable seamless restores for our users on Forge, we need to grant access to internal timescale schema and tables to the database owner.