### PR TITLE
Include pgBouncer in the Docker Image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+These are changes that will probably be included in the next release.
+
+### Added
+### Changed
+### Removed
+### Fixed
+
+## [v0.2.18] - 2020-07-27
+
+### Added
+ * [`pgBouncer`](https://www.pgbouncer.org/) as part of the image
+
 ## [v0.2.17] - 2020-07-17
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y less jq strace procps
 RUN apt-get update && apt-get install -y dumb-init daemontools
 
 RUN apt-get update \
-    && apt-get install -y postgresql-common pgbackrest lz4 libpq-dev libpq5 \
+    && apt-get install -y postgresql-common pgbouncer pgbackrest lz4 libpq-dev libpq5 \
     # forbid creation of a main cluster when package is installed
     && sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf
 


### PR DESCRIPTION
Adding pgBouncer adds a very few amount of bytes, but does allow us to
use the same Docker Image in some setups that have a sidecar pgBouncer
container, or a separate pod.