### PR TITLE
Include 2.0.0-rc2 libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ These are changes that will probably be included in the next release.
 ### Changed
 ### Removed
 
+## [v0.2.26] - 2020-10-28
+### Added
+ * Include libraries for Timescale 2.0.0-rc2
+
 ## [v0.2.25] - 2020-09-29
 ### Added
  * Include [promscale](https://github.com/timescale/promscale_extension) extension

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,8 +117,9 @@ ARG INSTALL_METHOD=docker-ha
 
 # If a specific GITHUB_TAG is provided, we will build that tag only. Otherwise
 # we build all the public (recent) releases
-RUN TS_VERSIONS="1.6.0 1.6.1 1.7.0 1.7.1 1.7.2 1.7.3 1.7.4" \
+RUN TS_VERSIONS="1.6.0 1.6.1 1.7.0 1.7.1 1.7.2 1.7.3 2.0.0-rc2 1.7.4" \
     && if [ "${GITHUB_TAG}" != "" ]; then TS_VERSIONS="${GITHUB_TAG}"; fi \
+    && cd /build/timescaledb && git pull \
     && set -e \
     && for pg in ${PG_VERSIONS}; do \
         for ts in ${TS_VERSIONS}; do \


### PR DESCRIPTION
By installing the latest stable (1.7.4) after installing 2.0.0-rc2 we
accomplish that the Docker Image *does* contain the 2.0.0-rc2 libraries,
but they are not the default version for Timescale.