### PR TITLE
Include TimescaleDB 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ These are changes that will probably be included in the next release.
 ### Changed
 ### Removed
 
+## [v0.2.30] - 2020-12-21
+### Changed
+ * Include (but not default to) Timescale 2.0.0
+
 ## [v0.2.29] - 2020-12-13
 ### Changed
  * Include (but not default to) Timescale 2.0.0-rc4

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ ARG INSTALL_METHOD=docker-ha
 
 # If a specific GITHUB_TAG is provided, we will build that tag only. Otherwise
 # we build all the public (recent) releases
-RUN TS_VERSIONS="1.6.0 1.6.1 1.7.0 1.7.1 1.7.2 1.7.3 2.0.0-rc4 1.7.4" \
+RUN TS_VERSIONS="1.6.0 1.6.1 1.7.0 1.7.1 1.7.2 1.7.3 2.0.0-rc3 2.0.0-rc4 2.0.0 1.7.4" \
     && if [ "${GITHUB_TAG}" != "" ]; then TS_VERSIONS="${GITHUB_TAG}"; fi \
     && cd /build/timescaledb && git pull \
     && set -e \


### PR DESCRIPTION
For completeness, we also include 2.0.0-rc3 and 2.0.0-rc4, as we would
otherwise force those users that upgraded to a Release Candidate to
immediately upgrade after this Docker Image is used.