### PR TITLE
Default to TimescaleDB 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ These are changes that will probably be included in the next release.
 ### Changed
 ### Removed
 
+## [v0.3.0] - 2021-01-04
+### Changed
+ * Default to Timescale 2.0.0
+
 ## [v0.2.30] - 2020-12-21
 ### Changed
  * Include (but not default to) Timescale 2.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ ARG INSTALL_METHOD=docker-ha
 
 # If a specific GITHUB_TAG is provided, we will build that tag only. Otherwise
 # we build all the public (recent) releases
-RUN TS_VERSIONS="1.6.0 1.6.1 1.7.0 1.7.1 1.7.2 1.7.3 2.0.0-rc3 2.0.0-rc4 2.0.0 1.7.4" \
+RUN TS_VERSIONS="1.6.0 1.6.1 1.7.0 1.7.1 1.7.2 1.7.3 1.7.4 2.0.0-rc3 2.0.0-rc4 2.0.0" \
     && if [ "${GITHUB_TAG}" != "" ]; then TS_VERSIONS="${GITHUB_TAG}"; fi \
     && cd /build/timescaledb && git pull \
     && set -e \


### PR DESCRIPTION
By compiling the 2.0.0 version last we ensure it becomes the default
version when installing `CREATE EXTENSION timescaledb`
