### PR TITLE
Publish images to timescale/timescaledb-ha

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ WIPTAG=$(TIMESCALEDB_RELEASE_URL)-pg$(PG_MAJOR)$(POSTFIX)-wip
 
 
 CICD_REPOSITORY?=registry.gitlab.com/timescale/timescaledb-docker-ha
-PUBLISH_REPOSITORY?=docker.io/timescaledev/timescaledb-ha
+PUBLISH_REPOSITORY?=docker.io/timescale/timescaledb-ha
 
 BUILDARGS=
 POSTFIX=

--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ Docker Images will be automatically published to Docker Hub for git tags startin
 
 They will be written under quite a few aliases, for example, for PostgreSQL 12.3 and Timescale 1.7.1, the following images will be built and pushed/overwritten:
 
-- timescaledev/timescaledb-ha:pg12-latest
-- timescaledev/timescaledb-ha:pg12-ts1.7-latest
-- timescaledev/timescaledb-ha:pg12.4-ts1.7-latest
-- timescaledev/timescaledb-ha:pg12.4-ts1.7.2-latest
+- timescale/timescaledb-ha:pg12-latest
+- timescale/timescaledb-ha:pg12-ts1.7-latest
+- timescale/timescaledb-ha:pg12.4-ts1.7-latest
+- timescale/timescaledb-ha:pg12.4-ts1.7.2-latest
 
 In addition, for every build, an immutable image will be created and pushed, which will carry a patch version at the end. These are most suited for production releases, for example:
-- timescaledev/timescaledb-ha:pg12.4-ts1.7.2-p0
-- timescaledev/timescaledb-ha:pg11.9-ts1.7.2-p3
+- timescale/timescaledb-ha:pg12.4-ts1.7.2-p0
+- timescale/timescaledb-ha:pg11.9-ts1.7.2-p3
 
 ## Patch process
 


### PR DESCRIPTION
We used to push to timescaledev/timescaledb-ha, it no longer really is a
dev image, but a production image.

Adresses issue #79