### PR TITLE
Add "docker" tag to builder job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,6 +62,7 @@ before_script:
 builder:
   only: [ "tags" ]
   stage: builder
+  tags: [ "docker" ]
   script:
   - PG_MAJOR=11 make push-builder
   - PG_MAJOR=12 make push-builder


### PR DESCRIPTION
This is required to activate a Gitlab runner. Previously, Gitlab still
ran the job even without a matching tag, but that no longer works.