### PR TITLE
Stamp release 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ These are changes that will probably be included in the next release.
 ### Changed
 ### Removed
 
+## [v0.3.3] - 2021-02-16
+### Added
+ * Include Extension [pg\_auth\_mon](https://github.com/RafiaSabih/pg_auth_mon)
+ * Include Extension [logerrors](https://github.com/munakoiso/logerrors)
+### Changed
+ * TimescaleDB [1.7.5](https://github.com/timescale/timescaledb/releases/tag/1.7.5) was released
+
 ## [v0.3.2] - 2021-01-28
 ### Changed
  * TimescaleDB [2.0.1](https://github.com/timescale/timescaledb/releases/tag/2.0.1) was released

--- a/Dockerfile
+++ b/Dockerfile
@@ -220,7 +220,7 @@ RUN if [ ! -z "${PG_LOGERRORS}" ]; then \
         cd /build \
         && git clone https://github.com/munakoiso/logerrors \
         && for pg in ${PG_VERSIONS}; do \
-            cd /build/pg_auth_mon && git reset HEAD --hard && git checkout "${PG_LOGERRORS}" \
+            cd /build/logerrors && git reset HEAD --hard && git checkout "${PG_LOGERRORS}" \
             && make clean && PG_CONFIG=/usr/lib/postgresql/${pg}/bin/pg_config make install || exit 1 ; \
         done; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ ARG INSTALL_METHOD=docker-ha
 
 # If a specific GITHUB_TAG is provided, we will build that tag only. Otherwise
 # we build all the public (recent) releases
-RUN TS_VERSIONS="1.6.0 1.6.1 1.7.0 1.7.1 1.7.2 1.7.3 1.7.4 2.0.0-rc3 2.0.0-rc4 2.0.0 2.0.1" \
+RUN TS_VERSIONS="1.6.0 1.6.1 1.7.0 1.7.1 1.7.2 1.7.3 1.7.4 1.7.5 2.0.0-rc3 2.0.0-rc4 2.0.0 2.0.1" \
     && if [ "${GITHUB_TAG}" != "" ]; then TS_VERSIONS="${GITHUB_TAG}"; fi \
     && cd /build/timescaledb && git pull \
     && set -e \


### PR DESCRIPTION
- [ ] Wait for 1.7.5 is actually released before triggering

PostgreSQL released security updates recently,
this will ensure our Docker Images will contain
PostgreSQL 11.11 and 12.6

TimescaleDB has had a patch release: 1.7.5.

Some new extensions