### PR TITLE
Allow extensions to be added to a live container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 These are changes that will probably be included in the next release.
 
 ### Added
+ * Allow additional extensions to be added to a running container
+
+   If enabled, this allows one to create new extension libraries and new supporting files
+   in their respective directories.
+   Files that are part of the Docker Image are guarded against mutations, so only *new* files
+   can be added.
 ### Changed
  * CI/CD has moved from gitlab to GitHub actions
  * Images now get pushed to `timescale/timescaledb-ha` (used to be `timescaledev/timescaledb-ha`)

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ DOCKER_TAG_LABELED=$(PG_MAJOR)$(DOCKER_TAG_POSTFIX)-labeled
 GITHUB_DOCKERLIB_POSTGRES_REF=master
 GITHUB_TIMESCALEDB_DOCKER_REF=master
 
+ALLOW_ADDING_EXTENSIONS?=true
+
 # We add a patch increment to all our immutable Docker Images. To figure out which patch number
 # to assign, we need 1 repository that is the canonical source of truth
 DOCKER_CANONICAL_URL?=https://index.docker.io/v1/repositories/timescale/timescaledb-ha
@@ -50,6 +52,7 @@ VAR_VERSION_INFO=version_info-$(PG_MAJOR)$(DOCKER_TAG_POSTFIX).log
 # afterwards, by using introspection, as minor versions may differ even when using the same
 # Dockerfile
 DOCKER_BUILD_COMMAND=docker build  \
+					 --build-arg ALLOW_ADDING_EXTENSIONS="$(ALLOW_ADDING_EXTENSIONS)" \
 					 --build-arg DEBIAN_REPO_MIRROR=$(DEBIAN_REPO_MIRROR) \
 					 --build-arg GITHUB_DOCKERLIB_POSTGRES_REF="$(GITHUB_DOCKERLIB_POSTGRES_REF)" \
 					 --build-arg GITHUB_TIMESCALEDB_DOCKER_REF="$(GITHUB_TIMESCALEDB_DOCKER_REF)" \
@@ -83,6 +86,7 @@ fast: PG_VERSIONS=12
 fast: POSTGIS_VERSIONS=
 fast: TIMESCALE_ANALYTICS_EXTENSION=
 fast: TIMESCALE_PROMSCALE_EXTENSION=
+fast: ALLOW_ADDING_EXTENSIONS=true
 fast: prepare
 
 # The prepare step does not build the final image, as we need to use introspection


### PR DESCRIPTION
By default, the directories supporting extensions and their files are
owned by root, and are readable by PostgreSQL.

This is (in general) a good thing: It ensures that these files cannot be
updated, not even if an end-user has access to the `superuser` of the
PostgreSQL cluster.

This does however prevent *any* live patching of these directories being
done on a live container, the container itself is running as a
non-privileged container in most environments, and therefore no files
can be added. This means that any change - even adding an extension
version - requires the container to be stopped and started using a
different Docker Image.

By allowing the *addition only* of new files to the directories by the
PostgreSQL user, we open up some Development opportunities, without
causing to many surprises for running processes.

This commit does the following:

1. make `postgres` own specific extension related directories
2. the existing files in the directory are still fully owned by the root user
3. the sticky bit is set on the directory

This ensures the following:

- *new* files can be created, modified and deleted by the `postgres` user
- *existing* files (in the image) cannot be deleted or modified by postgres