### PR TITLE
Make postgres own the timescale-analytics files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -157,25 +157,6 @@ RUN if [ ! -z "${TIMESCALE_PROMSCALE_EXTENSION}" ]; then \
         done; \
     fi
 
-ARG TIMESCALE_ANALYTICS_EXTENSION=
-# build and install the timescale-analytics extension
-RUN if [ ! -z "${TIMESCALE_ANALYTICS_EXTENSION}" -a -z "${OSS_ONLY}" ]; then \
-        curl https://sh.rustup.rs -sSf | bash -s -- -y \
-        && set -e \
-        && PATH="/root/.cargo/bin:${PATH}" \
-        && mkdir -p /build \
-        && cargo install --git https://github.com/JLockerman/pgx.git --branch timescale cargo-pgx \
-        && git clone https://github.com/timescale/timescale-analytics /build/timescale-analytics \
-        && for pg in ${PG_VERSIONS}; do \
-            if [ "${pg}" = "12" ]; then \
-                cargo pgx init --pg12 /usr/lib/postgresql/${pg}/bin/pg_config \
-                && cd /build/timescale-analytics && git reset HEAD --hard && git checkout ${TIMESCALE_ANALYTICS_EXTENSION} \
-                && git clean -f -x \
-                && cd extension && cargo pgx install --release; \
-            fi; \
-        done; \
-    fi
-
 # Protected Roles is a library that restricts the CREATEROLE/CREATEDB privileges of non-superusers.
 # It is a private timescale project and is therefore not included/built by default
 ARG TIMESCALE_TSDB_ADMIN=
@@ -239,6 +220,33 @@ RUN if [ "${ALLOW_ADDING_EXTENSIONS}" = "true" ]; then \
             done; \
         done ; \
     fi
+
+### Cargo tries to reuse many already downloaded libraries and crates registries
+### This does not work well if other users need to use cargo.
+### Therefore we cleanup the cargo directory without totally reinstalling cargo using rustup.
+RUN rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git"
+RUN chown postgres:postgres -R "${CARGO_HOME}"
+
+### The following tools will be installed with their files owned by postgres.
+### This allows the possibility of these files to be overwritten in a running container,
+### Therefore, anything that is installed as a user postgres must be regarded as highly experimental
+USER postgres
+ARG TIMESCALE_ANALYTICS_EXTENSION=
+# build and install the timescale-analytics extension
+RUN if [ ! -z "${TIMESCALE_ANALYTICS_EXTENSION}" -a -z "${OSS_ONLY}" ]; then \
+        set -e \
+        && cargo install --git https://github.com/JLockerman/pgx.git --branch timescale cargo-pgx \
+        && git clone https://github.com/timescale/timescale-analytics /build/timescale-analytics \
+        && for pg in ${PG_VERSIONS}; do \
+            if [ "${pg}" = "12" ]; then \
+                cargo pgx init --pg${pg} /usr/lib/postgresql/${pg}/bin/pg_config \
+                && cd /build/timescale-analytics && git reset HEAD --hard && git checkout ${TIMESCALE_ANALYTICS_EXTENSION} \
+                && git clean -f -x \
+                && cd extension && cargo pgx install --release; \
+            fi; \
+        done; \
+    fi
+USER root
 
 ## Cleanup
 RUN apt-get remove -y ${BUILD_PACKAGES}


### PR DESCRIPTION
- [x] Finish discussion whether this is a good idea

This allows overwriting of the libraries and sql files belonging to this
extension by the postgres user.