### PR TITLE
PostgreSQL 13 - Soft deprecation of 11 images

### DIFF
--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -17,20 +17,20 @@ jobs:
     strategy:
       matrix:
         include:
-        # This is the 'default' image, it contains PostgreSQL 11 and 12, and defaults to PostgreSQL 12 binaries
+        # This is the 'default' image, it contains PostgreSQL 12 and 13, and defaults to PostgreSQL 13 binaries
+        - pg_major: "13"
+          pg_versions: "13 12"
+        # This is the 12 image
         - pg_major: "12"
           pg_versions: "12 11"
-        # This is the 11 only image, should probably be retired
-        - pg_major: "11"
-          pg_versions: "11"
+        # This is the PostgreSQL 13 image containing only oss software
+        - pg_major: "13"
+          pg_versions: "13 12"
+          docker_extra_buildargs: ' --build-arg OSS_ONLY=" -DAPACHE_ONLY=1"'
+          docker_tag_postfix: '-oss'
         # This is the PostgreSQL 12 image containing only oss software
         - pg_major: "12"
           pg_versions: "12 11"
-          docker_extra_buildargs: ' --build-arg OSS_ONLY=" -DAPACHE_ONLY=1"'
-          docker_tag_postfix: '-oss'
-        # This is the PostgreSQL 11 image containing only oss software, should probably be retired
-        - pg_major: "11"
-          pg_versions: "11"
           docker_extra_buildargs: ' --build-arg OSS_ONLY=" -DAPACHE_ONLY=1"'
           docker_tag_postfix: '-oss'
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-PG_MAJOR?=12
+PG_MAJOR?=13
 # All PG_VERSIONS binaries/libraries will be included in the Dockerfile
 # specifying multiple versions will allow things like pg_upgrade etc to work.
-PG_VERSIONS?=12 11
+PG_VERSIONS?=13 12
 
 # Additional PostgreSQL extensions we want to include with specific version/commit tags
 POSTGIS_VERSIONS?="2.5 3"
-PG_AUTH_MON?=a38b2341
+PG_AUTH_MON?=v1.0
 PG_LOGERRORS?=3c55887b
 PG_SQLITE_FDW?=v1.3.1
 TIMESCALE_PROMSCALE_EXTENSION?=0.1.1
@@ -84,7 +84,7 @@ DOCKER_EXEC_COMMAND=docker exec -i $(DOCKER_TAG_PREPARE) timeout 60
 fast: DOCKER_EXTRA_BUILDARGS= --build-arg GITHUB_TAG=master
 fast: PG_AUTH_MON=
 fast: PG_LOGERRORS=
-fast: PG_VERSIONS=12
+fast: PG_VERSIONS=13
 fast: POSTGIS_VERSIONS=
 fast: TIMESCALE_ANALYTICS_EXTENSION=
 fast: TIMESCALE_PROMSCALE_EXTENSION=


### PR DESCRIPTION
# Support for PG 13 - prepare deprecation of PG 11

With this commit in, we can build Docker Images containing all the
software we need for PostgreSQL 13.

To make this work, we needed to fix a few things:

* `pg_auth_mon`: Bump tag to a PostgreSQL 13 supported version
* `timescale_analytics`: Only build PostgreSQL <version> and be explicit about
    the version when using `cargo pgx`, to avoid rust compilation
    errors.
* `timescaledb`: Ensure we only build 2.1+ for PostgreSQL 13

PostgreSQL 11 is not yet deprecated with this commit in, however both
the Makefile and GitHub Actions no longer build PostgreSQL 11 images.

