### PR TITLE
Add pg_stat_kcache libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,8 @@ RUN for pg in ${PG_VERSIONS}; do \
 
 RUN for pg in ${PG_VERSIONS}; do \
         apt-get install -y postgresql-${pg} postgresql-${pg}-dbgsym postgresql-plpython3-${pg} postgresql-plperl-${pg} postgresql-server-dev-${pg} \
-            postgresql-${pg}-pgextwlist postgresql-${pg}-hll postgresql-${pg}-pgrouting postgresql-${pg}-repack postgresql-${pg}-hypopg postgresql-${pg}-unit || exit 1; \
+            postgresql-${pg}-pgextwlist postgresql-${pg}-hll postgresql-${pg}-pgrouting postgresql-${pg}-repack postgresql-${pg}-hypopg postgresql-${pg}-unit \
+            postgresql-${pg}-pg-stat-kcache || exit 1; \
     done
 
 # We put Postgis in first, so these layers can be reused


### PR DESCRIPTION
https://github.com/powa-team/pg_stat_kcache is an extension that can
keep track of many system level metrics for us. It requires to be added
to the `shared_preload_libraries` to be useful.