### PR TITLE
Mark certain tools as required

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ RUN for t in deb deb-src; do \
     done
 RUN curl -s -o - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 
-# Some tools that are not strictly required for running PostgreSQL, but have a tiny
-# footprint and can be very valuable when troubleshooting a running container,
+# The following tools are required for some of the processes we (TimescaleDB) regularly
+# run inside the containers that use this Docker Image
 RUN apt-get update && apt-get install -y less jq strace procps
 
 # For debugging it is very useful if the Docker Image contains gdb(server). Even though it is


### PR DESCRIPTION
- jq is very useful in its interaction with pgbackrest --output json
- strace and procps are very useful for troubleshooting issues,
  this happens infrequently, but if it does happen, it is invaluable to
  have the tools available
- less is useful to read through some log files that get created, an
  example is pgbackrest async logs may grow big and may only exist
  inside the container