### PR TITLE
Use Debian Bullseye as the foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 These are changes that will probably be included in the next release.
 ### Added
 ### Changed
+ * Use [Debian Bullseye](https://wiki.debian.org/DebianBullseye) as the foundation of our Docker Image
 ### Removed
+ * Support for PostGIS 2.5
 ### Fixed
 
 ## [v0.4.24] - 2021-08-24

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,7 @@ RUN for file in $(find /usr/share/postgresql -name 'postgresql.conf.sample'); do
     done
 
 # timescaledb-tune, as well as timescaledb-parallel-copy
+# temporary using buster instead of $(lsb_release -s -c)
 RUN echo "deb https://packagecloud.io/timescale/timescaledb/debian/ buster main" > /etc/apt/sources.list.d/timescaledb.list
 RUN curl -L -s -o - https://packagecloud.io/timescale/timescaledb/gpgkey | apt-key add -
 RUN apt-get update && apt-get install -y timescaledb-tools

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PG_MAJOR?=13
 PG_VERSIONS?=13 12
 
 # Additional PostgreSQL extensions we want to include with specific version/commit tags
-POSTGIS_VERSIONS?="2.5 3"
+POSTGIS_VERSIONS?="3"
 PG_AUTH_MON?=v1.0
 PG_LOGERRORS?=3c55887b
 TIMESCALE_PROMSCALE_EXTENSION?=0.2.0


### PR DESCRIPTION
- [ ] Wait for the actual release (+1 week?) https://wiki.debian.org/DebianBullseye, which is planned for 2021-08-14

With Debian Bullseye we get glibc 2.31, which is useful for some of our
tools.