### PR TITLE
Include prebuilt Hot Forge binary

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -9,7 +9,7 @@ env:
   DEBIAN_REPO_MIRROR: cdn-aws.deb.debian.org
   INSTALL_METHOD: docker-ha
   TIMESCALE_TSDB_ADMIN: "0.1.1"
-  TIMESCALE_HOT_FORGE: ""
+  TIMESCALE_HOT_FORGE: "0.1.25"
 jobs:
   build-image:
     name: Build the default Docker Image


### PR DESCRIPTION
This significantly reduces the time to build a Docker Image