### PR TITLE
New Image including Hot Forge

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -9,7 +9,7 @@ env:
   DEBIAN_REPO_MIRROR: cdn-aws.deb.debian.org
   INSTALL_METHOD: docker-ha
   TIMESCALE_TSDB_ADMIN: "0.1.1"
-  TIMESCALE_HOT_FORGE: "0.1.25"
+  TIMESCALE_HOT_FORGE: "v0.1.25"
 jobs:
   build-image:
     name: Build the default Docker Image

--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -10,7 +10,7 @@ env:
   DOCKER_HUB_URL: docker.io/timescale/timescaledb-ha
   INSTALL_METHOD: docker-ha
   TIMESCALE_TSDB_ADMIN: "0.1.1"
-  TIMESCALE_HOT_FORGE: ""
+  TIMESCALE_HOT_FORGE: "v0.1.25"
 jobs:
   publish-image:
     name: Publish the Docker Images

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ These are changes that will probably be included in the next release.
 ### Removed
 ### Fixed
 
+## [v0.4.24] - 2021-08-24
+### Changed
+ * Download precompiled hot-forge instead of building from source
+ * Switch to rust Docker Image base (which is based on Debian itself)
+
 ## [v0.4.22] - 2021-08-19
 ### Changed
  * Include and default to Timescale 2.4.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,14 +129,16 @@ RUN ln -s /usr/local/bin/docker-entrypoint.sh /docker-entrypoint.sh
 # hot-forge is a project that allows hot-patching of postgres containers
 # It is currently a private timescale project and is therefore not included/built by default,
 # and never included in the OSS image.
+ARG PRIVATE_REPO_TOKEN=
 ARG TIMESCALE_HOT_FORGE=
 RUN if [ ! -z "${PRIVATE_REPO_TOKEN}" -a -z "${OSS_ONLY}" -a ! -z "${TIMESCALE_HOT_FORGE}" ]; then \
-        GH_REPO="https://api.github.com/repos/timescale/hot-forge/"; \
+        GH_REPO="https://api.github.com/repos/timescale/hot-forge"; \
         ASSET_ID="$(curl -sL --header "Authorization: token ${PRIVATE_REPO_TOKEN}" "${GH_REPO}/releases/tags/${TIMESCALE_HOT_FORGE}" | jq '.assets[0].id')"; \
         curl -sL --header "Authorization: token ${PRIVATE_REPO_TOKEN}" \
                  --header 'Accept: application/octet-stream' \
                  "${GH_REPO}/releases/assets/${ASSET_ID}" > /usr/local/bin/hot-forge || exit 1; \
         chmod 0755 /usr/local/bin/hot-forge ; \
+        hot-forge -V || exit 1 ; \
     fi
 
 # The following allows *new* files to be created, so that extensions can be added to a running container.
@@ -210,7 +212,6 @@ RUN if [ ! -z "${TIMESCALE_PROMSCALE_EXTENSION}" -a -z "${OSS_ONLY}" ]; then \
 # Protected Roles is a library that restricts the CREATEROLE/CREATEDB privileges of non-superusers.
 # It is a private timescale project and is therefore not included/built by default
 ARG TIMESCALE_TSDB_ADMIN=
-ARG PRIVATE_REPO_TOKEN=
 RUN if [ ! -z "${PRIVATE_REPO_TOKEN}" -a -z "${OSS_ONLY}" -a ! -z "${TIMESCALE_TSDB_ADMIN}" ]; then \
         cd /build \
         && git clone https://github-actions:${PRIVATE_REPO_TOKEN}@github.com/timescale/protected_roles \

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ VAR_VERSION_INFO=version_info-$(PG_MAJOR)$(DOCKER_TAG_POSTFIX).log
 # We label all the Docker Images with the versions of PostgreSQL, TimescaleDB and some other extensions
 # afterwards, by using introspection, as minor versions may differ even when using the same
 # Dockerfile
-DOCKER_BUILD_COMMAND=docker build  \
+DOCKER_BUILD_COMMAND=docker build --progress=plain \
 					 --build-arg ALLOW_ADDING_EXTENSIONS="$(ALLOW_ADDING_EXTENSIONS)" \
 					 --build-arg DEBIAN_REPO_MIRROR=$(DEBIAN_REPO_MIRROR) \
 					 --build-arg GITHUB_DOCKERLIB_POSTGRES_REF="$(GITHUB_DOCKERLIB_POSTGRES_REF)" \


### PR DESCRIPTION
#  Stamp 0.4.24

# Reintroduce Hot Forge
    
This commit reverts 3038c51ad72a1658688834c014d697fdd3b65778, however
the hot-forge tool no longer is built, it is downloaded.
