### PR TITLE
Use Ubuntu as a base for our Docker Image

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -6,7 +6,6 @@ on:
     - '**'
 
 env:
-  DEBIAN_REPO_MIRROR: cdn-aws.deb.debian.org
   INSTALL_METHOD: docker-ha
   TIMESCALE_TSDB_ADMIN: "0.1.1"
   TIMESCALE_HOT_FORGE: "v0.1.32"

--- a/.github/workflows/publish_builder.yaml
+++ b/.github/workflows/publish_builder.yaml
@@ -6,7 +6,6 @@ on:
     - cron:  '00 00 * * *'
 
 env:
-  DEBIAN_REPO_MIRROR: cdn-aws.deb.debian.org
   DOCKER_HUB_URL: docker.io/timescale/timescaledb-ha
   INSTALL_METHOD: docker-ha
   TIMESCALE_TSDB_ADMIN: "0.1.1"

--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -6,7 +6,6 @@ on:
     - 'v*'
 
 env:
-  DEBIAN_REPO_MIRROR: cdn-aws.deb.debian.org
   DOCKER_HUB_URL: docker.io/timescale/timescaledb-ha
   INSTALL_METHOD: docker-ha
   TIMESCALE_TSDB_ADMIN: "0.1.1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 These are changes that will probably be included in the next release.
 ### Added
+ * Installation of rust compiler inside the Dockerfile
 ### Changed
+ * Base the Docker Image on `ubuntu` (21.04) instead of `rust:debian`
 ### Removed
+ * Support for PostGIS 2.5
 ### Fixed
 
 ## [v0.4.29] - 2021-09-08

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PG_MAJOR?=13
 PG_VERSIONS?=13 12
 
 # Additional PostgreSQL extensions we want to include with specific version/commit tags
-POSTGIS_VERSIONS?="2.5 3"
+POSTGIS_VERSIONS?="3"
 PG_AUTH_MON?=v1.0
 PG_LOGERRORS?=3c55887b
 TIMESCALE_PROMSCALE_EXTENSION?=0.2.0
@@ -59,7 +59,6 @@ VAR_VERSION_INFO=version_info-$(PG_MAJOR)$(DOCKER_TAG_POSTFIX).log
 # Dockerfile
 DOCKER_BUILD_COMMAND=docker build --progress=plain \
 					 --build-arg ALLOW_ADDING_EXTENSIONS="$(ALLOW_ADDING_EXTENSIONS)" \
-					 --build-arg DEBIAN_REPO_MIRROR=$(DEBIAN_REPO_MIRROR) \
 					 --build-arg GITHUB_DOCKERLIB_POSTGRES_REF="$(GITHUB_DOCKERLIB_POSTGRES_REF)" \
 					 --build-arg GITHUB_TIMESCALEDB_DOCKER_REF="$(GITHUB_TIMESCALEDB_DOCKER_REF)" \
 					 --build-arg INSTALL_METHOD="$(INSTALL_METHOD)" \
@@ -129,7 +128,7 @@ prepare: pull-cached-image
 
 version_info-%.log: prepare
 	# In these steps we do some introspection to find out some details of the versions
-	# that are inside the Docker image. As we use the Debian packages, we do not know until
+	# that are inside the Docker image. As we use the Ubuntu packages, we do not know until
 	# after we have built the image, what patch version of PostgreSQL, or PostGIS is installed.
 	#
 	# We will then attach this information as OCI labels to the final Docker image

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This directory contains everything that allows us to create a Docker image with 
 - pgBackRest
 - scripts to make it all work in a Kubernetes Context
 
+Currently, our base image is Ubuntu, as we require glibc 2.33+.
+
 # Build images
 
 To build an image, run the following make target:


### PR DESCRIPTION
- [ ] Don't merge quickly, need some broad discussion first

# Use Ubuntu as a base for our Docker Image

To allow us to use specific glibc 2.33+ features, we need to find a way
to run glibc 2.33. Running multiple glibc versions inside the same
container is something we'd like to avoid, we've seen multiple glibc
related bugs in our lifetime, adding multiple glibc versions in the mix
would make debugging harder.

Debian (and rust:debian) has served us well, however even Debian's
latest release (bullseye, August 2021) cannot give us glibc 2.33.

Ubuntu however does give us glibc 2.33 - as Ubuntu is based upon Debian
the changes required are not that big for this Docker Image. Most of the
tools we use will be the same across the board, as most of our tools our
installed using external repositories.

Some significant changes to get here are required though:

## install rust using rustup-init

There was some (valid) criticism[1], around using rust as a base for the
image, instead of Debian. As Rust does not offer an Ubuntu variant, we
are no longer using a rust-flavored Docker Image as a base, however, we
do copy the exact rust installation sequence - including comparing
hashes for sanity for installing Rust.

## deprecate `apt-key` usage

Ubuntu 21.04 seems to still allow apt-key, however, in the future
apt-key usage will be deprecated. As the tweaking to get this fixed for
Ubuntu 21.10 was already done, I decided it best to keep it in here.

## remove PostGIS 2.5 support

There is no packaged PostGIS 2.5 available for Ubuntu 21.04. We however
have seen no evidence of PostGIS 2.5 usage with our Docker Image, we do
see evidence of usage of PostGIS 3, which is the default. Dropping
support for 2.5 therefore does not seem to be such a major issue

## disable errors as warnings

These build errors are seen on building older TimescaleDB versions
against a recent glibc. For more details, see[2]

1: https://github.com/timescale/timescaledb-docker-ha/pull/140#discussion_r702882671
2: https://github.com/timescale/timescaledb/issues/2770
