### PR TITLE
Feike/timescaledb 242

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ These are changes that will probably be included in the next release.
 
 ### Fixed
 
+## [v1.0.2] - 2021-09-20
+
+### Changed
+ * Include and default to Timescale 2.4.2
+
 
 ## [v1.0.1] - 2021-09-17
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -221,7 +221,7 @@ ARG INSTALL_METHOD=docker-ha
 
 # If a specific GITHUB_TAG is provided, we will build that tag only. Otherwise
 # we build all the public (recent) releases
-RUN TS_VERSIONS="1.6.0 1.6.1 1.7.0 1.7.1 1.7.2 1.7.3 1.7.4 1.7.5 2.0.0-rc3 2.0.0-rc4 2.0.0 2.0.1 2.0.2 2.1.0 2.1.1 2.2.0 2.2.1 2.3.0 2.3.1 2.4.0 2.4.1" \
+RUN TS_VERSIONS="1.6.0 1.6.1 1.7.0 1.7.1 1.7.2 1.7.3 1.7.4 1.7.5 2.0.0-rc3 2.0.0-rc4 2.0.0 2.0.1 2.0.2 2.1.0 2.1.1 2.2.0 2.2.1 2.3.0 2.3.1 2.4.0 2.4.1 2.4.2" \
     && if [ "${GITHUB_TAG}" != "" ]; then TS_VERSIONS="${GITHUB_TAG}"; fi \
     && cd /build/timescaledb && git pull \
     && set -e \


### PR DESCRIPTION

# Release v1.0.2: TimescaleDB 2.4.2

# Include and default to TimescaleDB 2.4.2
