### PR TITLE
Feike/hot forge reqs

### DIFF
--- a/.github/workflows/publish_builder.yaml
+++ b/.github/workflows/publish_builder.yaml
@@ -11,7 +11,6 @@ env:
   INSTALL_METHOD: docker-ha
   TIMESCALE_TSDB_ADMIN: "0.1.1"
   TIMESCALE_HOT_FORGE: "v0.1.35"
-  TIMESCALE_CLOUDUTILS: "v1.0.1-hf-1"
 jobs:
   build-image:
     name: Build the builder Docker Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -203,6 +203,11 @@ RUN for pg in ${PG_VERSIONS}; do \
 
 USER postgres
 
+RUN cargo install cargo-pgx
+RUN for pg in ${PG_VERSIONS}; do \
+        cargo pgx init --pg${pg} /usr/lib/postgresql/${pg}/bin/pg_config || exit 1 ; \
+    done
+
 ENV MAKEFLAGS=-j8
 
 ARG OSS_ONLY

--- a/Dockerfile
+++ b/Dockerfile
@@ -226,7 +226,7 @@ ARG INSTALL_METHOD=docker-ha
 
 # If a specific GITHUB_TAG is provided, we will build that tag only. Otherwise
 # we build all the public (recent) releases
-RUN TS_VERSIONS="1.6.0 1.6.1 1.7.0 1.7.1 1.7.2 1.7.3 1.7.4 1.7.5 2.0.0-rc3 2.0.0-rc4 2.0.0 2.0.1 2.0.2 2.1.0 2.1.1 2.2.0 2.2.1 2.3.0 2.3.1 2.4.0 2.4.1 2.4.2" \
+RUN TS_VERSIONS="2.4.2" \
     && if [ "${GITHUB_TAG}" != "" ]; then TS_VERSIONS="${GITHUB_TAG}"; fi \
     && cd /build/timescaledb && git pull \
     && set -e \

--- a/Dockerfile
+++ b/Dockerfile
@@ -365,8 +365,12 @@ RUN if [ "${ALLOW_ADDING_EXTENSIONS}" != "true" ]; then \
         done ; \
     fi
 
+USER postgres
+
 ## Cleanup
 FROM builder AS trimmed
+
+USER root
 
 RUN apt-get purge -y ${BUILD_PACKAGES}
 RUN apt-get autoremove -y \
@@ -382,6 +386,8 @@ RUN apt-get autoremove -y \
             /usr/local/rustup \
             /usr/local/cargo \
     && find /var/log -type f -exec truncate --size 0 {} \;
+
+USER postgres
 
 ## Create a smaller Docker image from the builder image
 FROM scratch

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,8 @@ publish-builder: builder
 		docker push $(DOCKER_PUBLISH_URLS):$(DOCKER_TAG_COMPILER); \
 		docker tag $(DOCKER_TAG_BUILDER) $(DOCKER_PUBLISH_URLS):$(DOCKER_TAG_BUILDER); \
 		docker push $(DOCKER_PUBLISH_URLS):$(DOCKER_TAG_BUILDER); \
-		export LSB_CODENAME="$$(docker run -ti --rm $(DOCKER_TAG_BUILDER) lsb_release -s -c | tr -d '[:space:]')"; \
+		docker run -i --rm $(DOCKER_TAG_BUILDER) lsb_release -s -c ; \
+		export LSB_CODENAME="$$(docker run -i --rm $(DOCKER_TAG_BUILDER) lsb_release -s -c | tr -d '[:space:]')"; \
 		docker tag $(DOCKER_TAG_BUILDER) $(DOCKER_PUBLISH_URLS):$(DOCKER_TAG_BUILDER)-$${LSB_CODENAME}; \
 		docker push $(DOCKER_PUBLISH_URLS):$(DOCKER_TAG_BUILDER)-$${LSB_CODENAME}; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -109,11 +109,15 @@ builder: compiler
 
 .PHONY: publish-builder
 publish-builder: builder
+	set -e ; \
 	for url in $(DOCKER_PUBLISH_URLS); do \
-		docker tag $(DOCKER_TAG_COMPILER) $(DOCKER_PUBLISH_URLS):$(DOCKER_TAG_COMPILER) || exit 1 ; \
-		docker push $(DOCKER_PUBLISH_URLS):$(DOCKER_TAG_COMPILER) || exit 1 ; \
-		docker tag $(DOCKER_TAG_BUILDER) $(DOCKER_PUBLISH_URLS):$(DOCKER_TAG_BUILDER) || exit 1 ; \
-		docker push $(DOCKER_PUBLISH_URLS):$(DOCKER_TAG_BUILDER) || exit 1 ; \
+		docker tag $(DOCKER_TAG_COMPILER) $(DOCKER_PUBLISH_URLS):$(DOCKER_TAG_COMPILER); \
+		docker push $(DOCKER_PUBLISH_URLS):$(DOCKER_TAG_COMPILER); \
+		docker tag $(DOCKER_TAG_BUILDER) $(DOCKER_PUBLISH_URLS):$(DOCKER_TAG_BUILDER); \
+		docker push $(DOCKER_PUBLISH_URLS):$(DOCKER_TAG_BUILDER); \
+		export LSB_CODENAME="$$(docker run -ti --rm $(DOCKER_TAG_BUILDER) lsb_release -s -c | tr -d '[:space:]')"; \
+		docker tag $(DOCKER_TAG_BUILDER) $(DOCKER_PUBLISH_URLS):$(DOCKER_TAG_BUILDER)-$${LSB_CODENAME}; \
+		docker push $(DOCKER_PUBLISH_URLS):$(DOCKER_TAG_BUILDER)-$${LSB_CODENAME}; \
 	done
 
 # This target always succeeds, as it is purely an speed optimization


### PR DESCRIPTION
# Publish Builder Image with an additionial tag pointing to the debian/ubuntu release

# Ensure correct user is set at every stage of the build

# `cargo-pgx init` for all builds to cache (and therefore speed up subsequent builds)