### PR TITLE
Only publish PostgreSQL 13 images from now on

### DIFF
--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -20,17 +20,9 @@ jobs:
         # This is the 'default' image, it contains PostgreSQL 12 and 13, and defaults to PostgreSQL 13 binaries
         - pg_major: "13"
           pg_versions: "13 12"
-        # This is the 12 image
-        - pg_major: "12"
-          pg_versions: "12 11"
         # This is the PostgreSQL 13 image containing only oss software
         - pg_major: "13"
           pg_versions: "13 12"
-          docker_extra_buildargs: ' --build-arg OSS_ONLY=" -DAPACHE_ONLY=1"'
-          docker_tag_postfix: '-oss'
-        # This is the PostgreSQL 12 image containing only oss software
-        - pg_major: "12"
-          pg_versions: "12 11"
           docker_extra_buildargs: ' --build-arg OSS_ONLY=" -DAPACHE_ONLY=1"'
           docker_tag_postfix: '-oss'
     runs-on: ubuntu-20.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -221,7 +221,7 @@ ARG INSTALL_METHOD=docker-ha
 
 # If a specific GITHUB_TAG is provided, we will build that tag only. Otherwise
 # we build all the public (recent) releases
-RUN TS_VERSIONS="1.6.0 1.6.1 1.7.0 1.7.1 1.7.2 1.7.3 1.7.4 1.7.5 2.0.0-rc3 2.0.0-rc4 2.0.0 2.0.1 2.0.2 2.1.0 2.1.1 2.2.0 2.2.1 2.3.0 2.3.1 2.4.0 2.4.1 2.4.2 2.5.0" \
+RUN TS_VERSIONS="2.1.0 2.1.1 2.2.0 2.2.1 2.3.0 2.3.1 2.4.0 2.4.1 2.4.2 2.5.0" \
     && if [ "${GITHUB_TAG}" != "" ]; then TS_VERSIONS="${GITHUB_TAG}"; fi \
     && cd /build/timescaledb && git pull \
     && set -e \


### PR DESCRIPTION
The 13 images still contain the PostgreSQL 12 binaries, so this change
only affects those that are still running PostgreSQL 11 only