### PR TITLE
Stamp release v1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ These are changes that will probably be included in the next release.
 
 ### Fixed
 
+## [v1.0.8] - 2021-11-11
+
+### Changed
+ * PostgreSQL [12.9](https://www.postgresql.org/docs/12/release-12-9.html) and [13.5](https://www.postgresql.org/docs/13/release-13-5.html) have been released
+ * Include dependencies to support native Raft support for Patroni [PySyncObj](https://github.com/bakwc/PySyncObj)
+
 ## [v1.0.7] - 2021-10-27
 
 ### Changed


### PR DESCRIPTION
Minor PostgreSQL upgrades have been stamped [13](https://github.com/postgres/postgres/commit/084346ccee8ead6b387a90cdf6a29036ae9ec77e) [12](https://github.com/postgres/postgres/commit/8a94efd9bb71c2d5473836ce4899aedb9b4cfb2e) in the repo and should be available somewhere on November 11th.

We should therefore not merge this PR before those releases are available in the Ubuntu repositories.

- [x] Wait for postgresql.org announcement of minor versions before merging

## [v1.0.8] - 2021-11-11

### Changed
 * PostgreSQL [12.9](https://www.postgresql.org/docs/12/release-12-9.html) and [13.5](https://www.postgresql.org/docs/13/release-13-5.html) have been released
 * Include dependencies to support native Raft support for Patroni [PySyncObj](https://github.com/bakwc/PySyncObj)

