### PR TITLE
Add pg_cron to shared_preload_libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,7 +145,7 @@ RUN apt-get install -y patroni
 
 RUN for file in $(find /usr/share/postgresql -name 'postgresql.conf.sample'); do \
         # We want timescaledb to be loaded in this image by every created cluster
-        sed -r -i "s/[#]*\s*(shared_preload_libraries)\s*=\s*'(.*)'/\1 = 'timescaledb,\2'/;s/,'/'/" $file \
+        sed -r -i "s/[#]*\s*(shared_preload_libraries)\s*=\s*'(.*)'/\1 = 'timescaledb,pg_cron,\2'/;s/,'/'/" $file \
         # We need to listen on all interfaces, otherwise PostgreSQL is not accessible
         && echo "listen_addresses = '*'" >> $file; \
     done


### PR DESCRIPTION
pg_cron was installed but not available.

Users still need to run `CREATE EXTENSION pg_cron;`