### PR TITLE
Sanity-check database objects before installing timescale extension

### DIFF
--- a/scripts/timescaledb/before-create.sql
+++ b/scripts/timescaledb/before-create.sql
@@ -3,18 +3,19 @@
 DO $$
 BEGIN
     IF EXISTS(
-    SELECT
-        1
-    FROM
-        pg_catalog.pg_namespace
-            WHERE nspname IN (
-                '_timescaledb_catalog',
-                '_timescaledb_internal'
-                '_timescaledb_cache',
-                '_timescaledb_config',
-                'timescaledb_experimental',
-                'timescaledb_information'
-            )
+        SELECT
+            1
+        FROM
+            pg_catalog.pg_namespace
+        WHERE nspname IN (
+            '_timescaledb_catalog',
+            '_timescaledb_internal'
+            '_timescaledb_cache',
+            '_timescaledb_config',
+            'timescaledb_experimental',
+            'timescaledb_information'
+        )
+        AND NOT EXISTS(SELECT 1 FROM pg_catalog.pg_extension WHERE extname = 'timescaledb')
     )
     THEN
         RAISE EXCEPTION 'Internal timescaledb schemas are present in the database, but timescaledb extension is missing'

--- a/scripts/timescaledb/before-create.sql
+++ b/scripts/timescaledb/before-create.sql
@@ -1,0 +1,24 @@
+-- Check if one of the timescaledb schemas are present in the database, while the extension is missing
+-- Note: this list assumes any new schemas added to the extension should be present here as well.
+DO $$
+BEGIN
+    IF EXISTS(
+    SELECT
+        1
+    FROM
+        pg_catalog.pg_namespace
+            WHERE nspname IN (
+                '_timescaledb_catalog',
+                '_timescaledb_internal'
+                '_timescaledb_cache',
+                '_timescaledb_config',
+                'timescaledb_experimental',
+                'timescaledb_information'
+            )
+    )
+    THEN
+        RAISE EXCEPTION 'Internal timescaledb schemas are present in the database, but timescaledb extension is missing'
+            USING HINT = 'Please, drop those schemas before installing timescaledb extension';
+    END IF;
+END
+$$;

--- a/scripts/timescaledb/before-update.sql
+++ b/scripts/timescaledb/before-update.sql
@@ -1,0 +1,35 @@
+-- Get all triggers that are not internal foreign key constraint triggers on timescale dependent schemas.
+-- Note: this list assumes any new schemas added to the extension should be present here as well.
+DO $$
+    BEGIN
+        IF EXISTS(
+                WITH depschemas AS
+                 (
+                     SELECT
+                         dep.objid
+                     FROM
+                         pg_catalog.pg_depend dep
+                             JOIN
+                         pg_extension ext
+                         ON (dep.refobjid = ext.oid)
+                     WHERE
+                             dep.deptype = 'e'
+                       AND classid = 2615
+                       AND ext.extname = 'timescaledb'
+                 )
+                SELECT
+                    1
+                FROM
+                    pg_catalog.pg_class cl
+                        JOIN depschemas ON (cl.relnamespace = depschemas.objid)
+                        JOIN pg_catalog.pg_trigger tg ON (cl.oid = tg.tgrelid)
+                        JOIN pg_catalog.pg_proc fn ON (tg.tgfoid = fn.oid)
+                WHERE
+                        tg.tgisinternal = 'f' OR fn.prolang != 12
+            )
+        THEN
+            RAISE EXCEPTION 'User-defined triggers are defined on tables in one of the internal timescaledb schemas.'
+                USING HINT = 'Please, drop those triggers before updating timescaledb extension';
+        END IF;
+    END
+$$;


### PR DESCRIPTION
Make sure there are no pre-existing schemas for "create extension" and
no triggers defined on timescale schemas for "alter extension update".