### PR TITLE
Build TimescaleDB Toolkit 1.5.1 from private repo

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -6,13 +6,16 @@ on:
     - '**'
 
 env:
+  DOCKER_CACHE_FROM: docker.io/timescale/timescaledb-ha:pg14-builder
   INSTALL_METHOD: docker-ha
-  TIMESCALE_TSDB_ADMIN: "1.0.0"
+  PG_VERSIONS: "14 13 12"
+  TIMESCALE_CLOUDUTILS: "v1.1.1"
   TIMESCALE_HOT_FORGE: "v0.1.36"
   TIMESCALE_OOM_GUARD: "v1.1.1"
-  TIMESCALE_CLOUDUTILS: "v1.1.1"
-  PG_VERSIONS: "14 13 12"
-  DOCKER_CACHE_FROM: docker.io/timescale/timescaledb-ha:pg14-builder
+  TIMESCALE_TSDB_ADMIN: "1.0.0"
+  TIMESCALEDB_TOOLKIT_EXTENSION_PREVIOUS: forge-stable-1.3.0 forge-stable-1.3.1 forge-stable-1.4.0
+  TIMESCALEDB_TOOLKIT_EXTENSION: 1.5.1-cloud
+  TIMESCALEDB_TOOLKIT_REPO: github.com/timescale/timescaledb-toolkit-private
 jobs:
   build-image:
     name: Build the default Docker Image

--- a/.github/workflows/publish_builder.yaml
+++ b/.github/workflows/publish_builder.yaml
@@ -9,10 +9,13 @@ on:
 env:
   DOCKER_HUB_URL: docker.io/timescale/timescaledb-ha
   INSTALL_METHOD: docker-ha
-  TIMESCALE_TSDB_ADMIN: "1.0.0"
+  TIMESCALE_CLOUDUTILS: "v1.1.1"
   TIMESCALE_HOT_FORGE: "v0.1.36"
   TIMESCALE_OOM_GUARD:  "v1.1.1"
-  TIMESCALE_CLOUDUTILS: "v1.1.1"
+  TIMESCALE_TSDB_ADMIN: "1.0.0"
+  TIMESCALEDB_TOOLKIT_EXTENSION_PREVIOUS: forge-stable-1.3.0 forge-stable-1.3.1 forge-stable-1.4.0
+  TIMESCALEDB_TOOLKIT_EXTENSION: 1.5.1-cloud
+  TIMESCALEDB_TOOLKIT_REPO: github.com/timescale/timescaledb-toolkit-private
   # This builder image is used to create patches in other environments.
   # Some of these patches still require PostgreSQL 12 support, therefore,
   # we include 3 versions for the builder image

--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -8,10 +8,13 @@ on:
 env:
   DOCKER_HUB_URL: docker.io/timescale/timescaledb-ha
   INSTALL_METHOD: docker-ha
-  TIMESCALE_TSDB_ADMIN: "1.0.0"
+  TIMESCALE_CLOUDUTILS: "v1.1.1"
   TIMESCALE_HOT_FORGE: "v0.1.36"
   TIMESCALE_OOM_GUARD:  "v1.1.1"
-  TIMESCALE_CLOUDUTILS: "v1.1.1"
+  TIMESCALE_TSDB_ADMIN: "1.0.0"
+  TIMESCALEDB_TOOLKIT_EXTENSION_PREVIOUS: forge-stable-1.3.0 forge-stable-1.3.1 forge-stable-1.4.0
+  TIMESCALEDB_TOOLKIT_EXTENSION: 1.5.1-cloud
+  TIMESCALEDB_TOOLKIT_REPO: github.com/timescale/timescaledb-toolkit-private
 jobs:
   publish-image:
     name: Publish the Docker Images

--- a/Dockerfile
+++ b/Dockerfile
@@ -354,13 +354,16 @@ RUN if [ ! -z "${PG_LOGERRORS}" ]; then \
 
 ARG TIMESCALEDB_TOOLKIT_EXTENSION=
 ARG TIMESCALEDB_TOOLKIT_EXTENSION_PREVIOUS=
+ARG TIMESCALEDB_TOOLKIT_REPO=github.com/timescale/timescaledb-toolkit
 # build and install the timescaledb-toolkit extension
-RUN  --mount=type=secret,uid=1000,id=AWS_ACCESS_KEY_ID --mount=type=secret,uid=1000,id=AWS_SECRET_ACCESS_KEY \
+RUN --mount=type=secret,uid=1000,id=AWS_ACCESS_KEY_ID \
+    --mount=type=secret,uid=1000,id=AWS_SECRET_ACCESS_KEY \
+    --mount=type=secret,uid=1000,id=private_repo_token \
     if [ ! -z "${TIMESCALEDB_TOOLKIT_EXTENSION}" -a -z "${OSS_ONLY}" ]; then \
         [ -f "/run/secrets/AWS_ACCESS_KEY_ID" ] && export AWS_ACCESS_KEY_ID="$(cat /run/secrets/AWS_ACCESS_KEY_ID)" ; \
         [ -f "/run/secrets/AWS_SECRET_ACCESS_KEY" ] && export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/AWS_SECRET_ACCESS_KEY)" ; \
         set -e \
-        && git clone https://github.com/timescale/timescaledb-toolkit /build/timescaledb-toolkit \
+        && git clone "https://github-actions:$(cat ${REPO_SECRET_FILE} 2>/dev/null || true)@${TIMESCALEDB_TOOLKIT_REPO}" /build/timescaledb-toolkit \
         && cd /build/timescaledb-toolkit \
         && for pg in ${PG_VERSIONS}; do \
             /build/scripts/install_timescaledb-toolkit.sh ${pg} ${TIMESCALEDB_TOOLKIT_EXTENSION_PREVIOUS} ${TIMESCALEDB_TOOLKIT_EXTENSION} || exit 1 ; \

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ PG_LOGERRORS?=3c55887b
 TIMESCALE_PROMSCALE_EXTENSION?=0.3.0
 TIMESCALEDB_TOOLKIT_EXTENSION?=forge-stable-1.4.0
 TIMESCALEDB_TOOLKIT_EXTENSION_PREVIOUS?=forge-stable-1.3.0 forge-stable-1.3.1
+TIMESCALEDB_TOOLKIT_REPO?=github.com/timescale/timescaledb-toolkit
 TIMESCALE_TSDB_ADMIN?=
 TIMESCALE_HOT_FORGE?=
 TIMESCALE_OOM_GUARD?=
@@ -80,6 +81,7 @@ DOCKER_BUILD_COMMAND=docker build --progress=plain \
 					 --build-arg TIMESCALE_TSDB_ADMIN="$(TIMESCALE_TSDB_ADMIN)" \
 					 --build-arg TIMESCALEDB_TOOLKIT_EXTENSION_PREVIOUS="$(TIMESCALEDB_TOOLKIT_EXTENSION_PREVIOUS)" \
 					 --build-arg TIMESCALEDB_TOOLKIT_EXTENSION="$(TIMESCALEDB_TOOLKIT_EXTENSION)" \
+					 --build-arg TIMESCALEDB_TOOLKIT_REPO="$(TIMESCALEDB_TOOLKIT_REPO)" \
 					 --cache-from "$(DOCKER_CACHE_FROM)" \
 					 --label com.timescaledb.image.install_method=$(INSTALL_METHOD) \
 					 --label org.opencontainers.image.created="$$(date -Iseconds --utc)" \


### PR DESCRIPTION
# Build TimescaleDB Toolkit 1.5.1 from private repo

# Disallow new installations for older Toolkit versions

This ensures that all new installations will be on toolkit 1.5.1 or
higher, current deployments that have Toolkit < 1.5.1 installed will
continue to work, this only affects new installations or upgrades to
versions < 1.5.1
