### PR TITLE
Use Ubuntu 21.10 as a base for our Docker Image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,21 @@ These are changes that will probably be included in the next release.
 
 ## [future release]
 
+## [v1.2.0] - 2022-03-11
+
+Minor release bump as we change Ubuntu to 21.10, which includes a higher
+version of `glibc`.
+
+### Changed
+
+* Use Ubuntu 21.10 as a base image instead of Ubuntu 21.04
+* Patroni was updated to [2.1.3](<https://patroni.readthedocs.io/en/latest/releases.html#version-2-1-3>)
+
 ## [v1.1.9] - 2022-02-23
 
 ### Changed
 
-* Patroni was updated to [2.1.3](https://patroni.readthedocs.io/en/latest/releases.html#version-2-1-3)
+* ~Patroni was updated to [2.1.3]~ Due to packaging problems, Patroni was still at 2.1.2 for this release.
 
 ## [v1.1.8] - 2022-02-17
 
@@ -22,6 +32,7 @@ These are changes that will probably be included in the next release.
 * Include and default to [TimescaleDB 2.6.0](https://github.com/timescale/timescaledb/releases/tag/2.6.0)
 
 ## [v1.1.7] - 2022-02-17
+
 ### Changed
 
 * Include Timescale Cloudutils 1.1.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,9 @@ ARG PG_MAJOR=13
 ## the changes required are not that big for this Docker Image. Most of the
 ## tools we use will be the same across the board, as most of our tools our
 ## installed using external repositories.
-FROM ubuntu:21.04 AS compiler
+FROM ubuntu:21.10 AS compiler
 
+ENV DEBIAN_FRONTEND=noninteractive
 # We need full control over the running user, including the UID, therefore we
 # create the postgres user as the first thing on our list
 RUN adduser --home /home/postgres --uid 1000 --disabled-password --gecos "" postgres
@@ -155,8 +156,10 @@ FROM compiler as builder
 ARG PG_VERSIONS
 
 # timescaledb-tune, as well as timescaledb-parallel-copy
+# TODO: Replace `focal` with `$(lsb_release -s -c)` once
+# we switch to Ubuntu 22.04.
 RUN wget -O - https://packagecloud.io/timescale/timescaledb/gpgkey | gpg --dearmor --output /usr/share/keyrings/timescaledb.keyring
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/timescaledb.keyring] https://packagecloud.io/timescale/timescaledb/ubuntu/ $(lsb_release -s -c) main" > /etc/apt/sources.list.d/timescaledb.list
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/timescaledb.keyring] https://packagecloud.io/timescale/timescaledb/ubuntu/ focal main" > /etc/apt/sources.list.d/timescaledb.list
 
 RUN apt-get update && apt-get install -y timescaledb-tools
 


### PR DESCRIPTION
The https://ubuntu.com/about/release-cycle informs us that support for
Ubuntu 21.04 has ended, and we should therefore upgrade to a newer
Ubuntu release.