### PR TITLE
Build TimescaleDB Toolkit from public repo again

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -15,7 +15,7 @@ env:
   TIMESCALE_TSDB_ADMIN: "1.0.0"
   TIMESCALEDB_TOOLKIT_EXTENSION_PREVIOUS: forge-stable-1.3.0 forge-stable-1.3.1 forge-stable-1.4.0
   TIMESCALEDB_TOOLKIT_EXTENSION: 1.5.1-cloud
-  TIMESCALEDB_TOOLKIT_REPO: github.com/timescale/timescaledb-toolkit-private
+  TIMESCALEDB_TOOLKIT_REPO: github.com/timescale/timescaledb-toolkit
 jobs:
   build-image:
     name: Build the default Docker Image

--- a/.github/workflows/publish_builder.yaml
+++ b/.github/workflows/publish_builder.yaml
@@ -15,7 +15,7 @@ env:
   TIMESCALE_TSDB_ADMIN: "1.0.0"
   TIMESCALEDB_TOOLKIT_EXTENSION_PREVIOUS: forge-stable-1.3.0 forge-stable-1.3.1 forge-stable-1.4.0
   TIMESCALEDB_TOOLKIT_EXTENSION: 1.5.1-cloud
-  TIMESCALEDB_TOOLKIT_REPO: github.com/timescale/timescaledb-toolkit-private
+  TIMESCALEDB_TOOLKIT_REPO: github.com/timescale/timescaledb-toolkit
   # This builder image is used to create patches in other environments.
   # Some of these patches still require PostgreSQL 12 support, therefore,
   # we include 3 versions for the builder image

--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -14,7 +14,7 @@ env:
   TIMESCALE_TSDB_ADMIN: "1.0.0"
   TIMESCALEDB_TOOLKIT_EXTENSION_PREVIOUS: forge-stable-1.3.0 forge-stable-1.3.1 forge-stable-1.4.0
   TIMESCALEDB_TOOLKIT_EXTENSION: 1.5.1-cloud
-  TIMESCALEDB_TOOLKIT_REPO: github.com/timescale/timescaledb-toolkit-private
+  TIMESCALEDB_TOOLKIT_REPO: github.com/timescale/timescaledb-toolkit
 jobs:
   publish-image:
     name: Publish the Docker Images

--- a/Dockerfile
+++ b/Dockerfile
@@ -359,14 +359,9 @@ ARG TIMESCALEDB_TOOLKIT_EXTENSION=
 ARG TIMESCALEDB_TOOLKIT_EXTENSION_PREVIOUS=
 ARG TIMESCALEDB_TOOLKIT_REPO=github.com/timescale/timescaledb-toolkit
 # build and install the timescaledb-toolkit extension
-RUN --mount=type=secret,uid=1000,id=AWS_ACCESS_KEY_ID \
-    --mount=type=secret,uid=1000,id=AWS_SECRET_ACCESS_KEY \
-    --mount=type=secret,uid=1000,id=private_repo_token \
-    if [ ! -z "${TIMESCALEDB_TOOLKIT_EXTENSION}" -a -z "${OSS_ONLY}" ]; then \
-        [ -f "/run/secrets/AWS_ACCESS_KEY_ID" ] && export AWS_ACCESS_KEY_ID="$(cat /run/secrets/AWS_ACCESS_KEY_ID)" ; \
-        [ -f "/run/secrets/AWS_SECRET_ACCESS_KEY" ] && export AWS_SECRET_ACCESS_KEY="$(cat /run/secrets/AWS_SECRET_ACCESS_KEY)" ; \
+RUN if [ ! -z "${TIMESCALEDB_TOOLKIT_EXTENSION}" -a -z "${OSS_ONLY}" ]; then \
         set -e \
-        && git clone "https://github-actions:$(cat ${REPO_SECRET_FILE} 2>/dev/null || true)@${TIMESCALEDB_TOOLKIT_REPO}" /build/timescaledb-toolkit \
+        && git clone "https://${TIMESCALEDB_TOOLKIT_REPO}" /build/timescaledb-toolkit \
         && cd /build/timescaledb-toolkit \
         && for pg in ${PG_VERSIONS}; do \
             /build/scripts/install_timescaledb-toolkit.sh ${pg} ${TIMESCALEDB_TOOLKIT_EXTENSION_PREVIOUS} ${TIMESCALEDB_TOOLKIT_EXTENSION} || exit 1 ; \


### PR DESCRIPTION
This is basically a revert of commit 922657d6, which was needed to
include a security fix that wasn't part of the public repository yet.