### PR TITLE
Stamp release v1.2.3

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -9,7 +9,7 @@ env:
   DOCKER_CACHE_FROM: docker.io/timescale/timescaledb-ha:pg14-builder
   INSTALL_METHOD: docker-ha
   PG_VERSIONS: "14 13 12"
-  TIMESCALE_CLOUDUTILS: "v1.1.1"
+  TIMESCALE_CLOUDUTILS: "v1.1.2"
   TIMESCALE_HOT_FORGE: "v0.1.36"
   TIMESCALE_OOM_GUARD: "v1.1.1"
   TIMESCALE_TSDB_ADMIN: "1.0.0"

--- a/.github/workflows/publish_builder.yaml
+++ b/.github/workflows/publish_builder.yaml
@@ -9,7 +9,7 @@ on:
 env:
   DOCKER_HUB_URL: docker.io/timescale/timescaledb-ha
   INSTALL_METHOD: docker-ha
-  TIMESCALE_CLOUDUTILS: "v1.1.1"
+  TIMESCALE_CLOUDUTILS: "v1.1.2"
   TIMESCALE_HOT_FORGE: "v0.1.36"
   TIMESCALE_OOM_GUARD:  "v1.1.1"
   TIMESCALE_TSDB_ADMIN: "1.0.0"

--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -8,7 +8,7 @@ on:
 env:
   DOCKER_HUB_URL: docker.io/timescale/timescaledb-ha
   INSTALL_METHOD: docker-ha
-  TIMESCALE_CLOUDUTILS: "v1.1.1"
+  TIMESCALE_CLOUDUTILS: "v1.1.2"
   TIMESCALE_HOT_FORGE: "v0.1.36"
   TIMESCALE_OOM_GUARD:  "v1.1.1"
   TIMESCALE_TSDB_ADMIN: "1.0.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ These are changes that will probably be included in the next release.
 
 ## [future release]
 
+## [v1.2.3] - 2022-04-11
+
+### Changed
+
+* Include and default to [TimescaleDB 2.6.1](https://github.com/timescale/timescaledb/releases/tag/2.6.1)
+* Include Cloudutils v1.1.2
+
 ## [v1.2.2] - 2022-04-06
 
 * Upgrade TimescaleDB Toolkit extension to [1.6.0](https://github.com/timescale/timescaledb-toolkit/releases/tag/1.6.0)

--- a/Dockerfile
+++ b/Dockerfile
@@ -242,7 +242,7 @@ COPY build_scripts /build/scripts
 
 # If a specific GITHUB_TAG is provided, we will build that tag only. Otherwise
 # we build all the public (recent) releases
-RUN TS_VERSIONS="1.7.5 2.1.0 2.1.1 2.2.0 2.2.1 2.3.0 2.3.1 2.4.0 2.4.1 2.4.2 2.5.0 2.5.1 2.5.2 2.6.0" \
+RUN TS_VERSIONS="1.7.5 2.1.0 2.1.1 2.2.0 2.2.1 2.3.0 2.3.1 2.4.0 2.4.1 2.4.2 2.5.0 2.5.1 2.5.2 2.6.0 2.6.1" \
     && if [ "${GITHUB_TAG}" != "" ]; then TS_VERSIONS="${GITHUB_TAG}"; fi \
     && cd /build/timescaledb && git pull \
     && set -e \


### PR DESCRIPTION
# Stamp v1.2.3

Changed

* Include and default to [TimescaleDB 2.6.1](https://github.com/timescale/timescaledb/releases/tag/2.6.1)
* Include Cloudutils v1.1.2


