### PR TITLE
Bump cloudutils to v1.1.3

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -9,7 +9,7 @@ env:
   DOCKER_CACHE_FROM: docker.io/timescale/timescaledb-ha:pg14-builder
   INSTALL_METHOD: docker-ha
   PG_VERSIONS: "14 13 12"
-  TIMESCALE_CLOUDUTILS: "v1.1.2"
+  TIMESCALE_CLOUDUTILS: "v1.1.3"
   TIMESCALE_HOT_FORGE: "v0.1.36"
   TIMESCALE_OOM_GUARD: "v1.1.1"
   TIMESCALE_TSDB_ADMIN: "1.0.0"

--- a/.github/workflows/publish_builder.yaml
+++ b/.github/workflows/publish_builder.yaml
@@ -9,7 +9,7 @@ on:
 env:
   DOCKER_HUB_URL: docker.io/timescale/timescaledb-ha
   INSTALL_METHOD: docker-ha
-  TIMESCALE_CLOUDUTILS: "v1.1.2"
+  TIMESCALE_CLOUDUTILS: "v1.1.3"
   TIMESCALE_HOT_FORGE: "v0.1.36"
   TIMESCALE_OOM_GUARD:  "v1.1.1"
   TIMESCALE_TSDB_ADMIN: "1.0.0"

--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -8,7 +8,7 @@ on:
 env:
   DOCKER_HUB_URL: docker.io/timescale/timescaledb-ha
   INSTALL_METHOD: docker-ha
-  TIMESCALE_CLOUDUTILS: "v1.1.2"
+  TIMESCALE_CLOUDUTILS: "v1.1.3"
   TIMESCALE_HOT_FORGE: "v0.1.36"
   TIMESCALE_OOM_GUARD:  "v1.1.1"
   TIMESCALE_TSDB_ADMIN: "1.0.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ These are changes that will probably be included in the next release.
 
 ## [future release]
 
+###
+
+  * Include Timescale Cloudutils 1.1.3
+
 ## [v1.2.3] - 2022-04-11
 
 ### Changed


### PR DESCRIPTION
Contains several bugfixes:
  * Role propagation commands now properly propagate NOINHERIT
  * Newly added data nodes will now correctly have all previosly created roles set