### PR TITLE
Feike/deprecate versions

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -17,7 +17,7 @@ env:
   TIMESCALE_OOM_GUARD: "v1.2.0"
   TIMESCALE_STATIC_PRIMARY: "true"
   TIMESCALE_TSDB_ADMIN: "1.0.0"
-  TIMESCALEDB_TOOLKIT_EXTENSIONS: forge-stable-1.3.1 1.5.1-cloud 1.6.0 1.7.0
+  TIMESCALEDB_TOOLKIT_EXTENSIONS: 1.6.0 1.7.0
   TIMESCALEDB_TOOLKIT_REPO: github.com/timescale/timescaledb-toolkit
 jobs:
   build-image:

--- a/.github/workflows/publish_compiler.yaml
+++ b/.github/workflows/publish_compiler.yaml
@@ -13,8 +13,6 @@ env:
   TIMESCALE_HOT_FORGE: "v0.1.37"
   TIMESCALE_OOM_GUARD:  "v1.2.0"
   TIMESCALE_TSDB_ADMIN: "1.0.0"
-  TIMESCALEDB_TOOLKIT_REPO: github.com/timescale/timescaledb-toolkit
-  TIMESCALEDB_TOOLKIT_EXTENSIONS: forge-stable-1.3.1 1.5.1-cloud 1.6.0 1.7.0
 
   # This compiler image is used to create patches in other environments.
   # Some of these patches still require PostgreSQL 12 support, therefore,

--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -13,7 +13,7 @@ env:
   TIMESCALE_OOM_GUARD:  "v1.2.0"
   TIMESCALE_STATIC_PRIMARY: ''
   TIMESCALE_TSDB_ADMIN: "1.0.0"
-  TIMESCALEDB_TOOLKIT_EXTENSIONS: forge-stable-1.3.1 1.5.1-cloud 1.6.0 1.7.0
+  TIMESCALEDB_TOOLKIT_EXTENSIONS: 1.6.0 1.7.0
   TIMESCALEDB_TOOLKIT_REPO: github.com/timescale/timescaledb-toolkit
 jobs:
   publish-image:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,53 @@ These are changes that will probably be included in the next release.
 
 ## [future release]
 
+## [v1.4.0] - 2022-06-03
+
+This release removes a lot of minor versions of TimescaleDB. We keep the following versions for
+compatibility with older Docker Images:
+
+* 1.7.5 - This version is the final version 1.x.x version of TimescaleDB.for PostgreSQL 11 users.
+    This version is only available for PostgreSQL 12.
+    Having this version in the Docker Image allows this Image to be a stepping stone in a migration
+    from PostgreSQL 11 and/or TimescaleDB 1.7.5, using `pg_dump` and `pg_restore` for example.
+* 2.6.1 - The final point release for the previous minor release
+* 2.7.0 - The latest TimescaleDB release
+
+For those users that are currently running a TimescaleDB version that is removed from this image,
+they are adviced to update their TimescaleDB extension to 2.7.0 *prior* to using the newer Docker
+Image.
+
+The latest Docker Image that allows you to run many previous minor versions to 2.7.0 is:
+
+```shell
+timescale/timescaledb-ha:pg14.3-ts2.7.0-p1
+```
+
+This release also deprecates versions of `timescaledb_toolkit`. The same advice applies for this
+extension as for the `timescaledb` extension, to update the extension to 1.7.0 *prior* to using the
+newer Docker Image.
+
+### Removed
+
+* TimescaleDB versions:
+  * 2.1.0
+  * 2.1.1
+  * 2.2.0
+  * 2.2.1
+  * 2.3.0
+  * 2.3.1
+  * 2.4.0
+  * 2.4.1
+  * 2.4.2
+  * 2.5.0
+  * 2.5.1
+  * 2.5.2
+  * 2.6.0
+
+* TimescaleDB Toolkit versions:
+  * forge-stable-1.3.1
+  * 1.5.1-cloud
+
 ## [v1.3.4] - 2022-06-03
 
 Include timescaledb_cloudutils v1.1.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -254,7 +254,7 @@ COPY build_scripts /build/scripts
 
 # If a specific GITHUB_TAG is provided, we will build that tag only. Otherwise
 # we build all the public (recent) releases
-RUN TS_VERSIONS="1.7.5 2.1.0 2.1.1 2.2.0 2.2.1 2.3.0 2.3.1 2.4.0 2.4.1 2.4.2 2.5.0 2.5.1 2.5.2 2.6.0 2.6.1 2.7.0" \
+RUN TS_VERSIONS="1.7.5 2.6.1 2.7.0" \
     && if [ "${GITHUB_TAG}" != "" ]; then TS_VERSIONS="${GITHUB_TAG}"; fi \
     && cd /build/timescaledb && git pull \
     && set -e \


### PR DESCRIPTION
This release removes a lot of versions of TimescaleDB. We keep the following versions for
compatibility with older Docker Images:

* 1.7.5 - This version is the final version for PostgreSQL 11 users.
    Keeping it in the Docker Image should allow a user to create a database with PostgreSQL 14,
    and TimescaleDB 1.7.5, allowing a `pg_dump` to be done against the PostgreSQL 11 database,
    and a `pg_restore` against the PostgreSQL 14 database.
* 2.6.1 - The final point release for the previous minor release
* 2.7.0 - The latest TimescaleDB release

For those users that are currently running a TimescaleDB version that is removed from this image,
they are adviced to update their TimescaleDB extension to 2.7.0 *prior* to using the newer Docker
Image.

The latest Docker Image that allows you to upgrade from any previous version to 2.7.0 is:

```shell
timescale/timescaledb-ha:pg14.3-ts2.7.0-p1
```

This release also deprecates versions of `timescaledb_toolkit`. The same advice applies for this
extension as for the `timescaledb` extension, to update the extension to 1.7.0 *prior* to using the
newer Docker Image.

### Removed

* TimescaleDB versions:
  * 2.1.0
  * 2.1.1
  * 2.2.0
  * 2.2.1
  * 2.3.0
  * 2.3.1
  * 2.4.0
  * 2.4.1
  * 2.4.2
  * 2.5.0
  * 2.5.1
  * 2.5.2
  * 2.6.0

* TimescaleDB Toolkit versions:
  * forge-stable-1.3.1
  * 1.5.1-cloud