### PR TITLE
Publish tagged pg12 images

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - '**'
+    paths-ignore:
+    - '.github/workflows/publish*.yaml'
 
 env:
   DOCKER_CACHE_FROM: docker.io/timescale/timescaledb-ha:pg14-compiler

--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -36,6 +36,12 @@ jobs:
           pg_versions: "13 12"
           docker_extra_buildargs: ' --build-arg OSS_ONLY=" -DAPACHE_ONLY=1"'
           docker_tag_postfix: '-oss'
+        - pg_major: "12"
+          pg_versions: "12"
+        - pg_major: "12"
+          pg_versions: "12"
+          docker_extra_buildargs: ' --build-arg OSS_ONLY=" -DAPACHE_ONLY=1"'
+          docker_tag_postfix: '-oss'
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code


### PR DESCRIPTION
Even though the pg14 and pg13 images can be used for pg12 deployments
when setting a sane PATH, some users would like to have a tagged pg12
release as well.

As we build these images in parallel, it seems ok to keep publishing
pg12 alongside the pg13 and pg14 images.