### PR TITLE
Feike/patroni single primary multi version

### DIFF
--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -26,7 +26,7 @@ jobs:
           pg_versions: "14 13 12"
         # This is the 'default' image, along with Patroni changes to support static primaries
         - pg_major: "14"
-          pg_versions: "14"
+          pg_versions: "14 13 12"
           patroni_static_primary: "true"
           docker_tag_postfix: "-patroni-static-primary"
         # This is the PostgreSQL 14 image containing only oss software

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ These are changes that will probably be included in the next release.
 
 ## [future release]
 
+## [v1.3.2] - 2022-05-20
+
+### Changed
+
+* Ensure experimental Patroni image also supports PostgreSQL 12 and 13
+
 ## [v1.3.1] - 2022-05-20
 
 ### Changed


### PR DESCRIPTION
For those environments that want to run the experimental Patroni version, but still support PostgreSQL 12 and 13 databases, we should ensure the final Docker Image contains those versions as well.