### PR TITLE
Publish the compiler image with a minor tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,9 @@ publish-compiler: compiler
 	for url in $(DOCKER_PUBLISH_URLS); do \
 		docker tag $(DOCKER_TAG_COMPILER) $(DOCKER_PUBLISH_URLS):$(DOCKER_TAG_COMPILER) || exit 1 ; \
 		docker push $(DOCKER_PUBLISH_URLS):$(DOCKER_TAG_COMPILER) || exit 1 ; \
+		PGMINOR=$$(docker run -ti $(DOCKER_TAG_COMPILER) psql --version | awk '{print $$3}') ;\
+		docker tag $(DOCKER_TAG_COMPILER) $(DOCKER_PUBLISH_URLS):pg$${PGMINOR}-compiler || exit 1 ; \
+		docker push $(DOCKER_PUBLISH_URLS):pg$${PGMINOR}-compiler || exit 1 ; \
 	done
 
 # This target always succeeds, as it is purely an speed optimization


### PR DESCRIPTION
When compiling tools against PostgreSQL, the minor version sometimes
*does* matter in the resulting library/binary.

To ensure we can compile against older minor versions than the latest
version, we also tag the compiler image with the current minor
PostgreSQL version.

This doesn't include any heavy lifting, only creating an alias for the
Docker Image that is already built.