### PR TITLE
Add apt-get upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,8 @@ RUN adduser --home /home/postgres --uid 1000 --disabled-password --gecos "" post
 RUN echo 'APT::Install-Recommends "false";' >> /etc/apt/apt.conf.d/01norecommend
 RUN echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf.d/01norecommend
 
-# Install the highlest level dependencies
-RUN apt-get update \
+# Make sure we're as up-to-date as possible, and install the highlest level dependencies
+RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y ca-certificates curl gnupg1 gpg gpg-agent locales lsb-release wget
 
 RUN mkdir -p /build/scripts


### PR DESCRIPTION
Ubuntu's repositories are updated more often than their docker images are, so this can sometimes
install security fixes that might otherwise be missed.

For example, today while I was testing the build of timescale 2.7.0 there was a libpcre vulnerability that was fixed in the ubuntu repository, but not in the base image, so the result was the image I created was still affected.