### PR TITLE
Feike/ts271

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ These are changes that will probably be included in the next release.
 
 ## [future release]
 
+## [v1.4.6] - 2022-07-07
+
+* Include and default to [TimescaleDB 2.7.1](https://github.com/timescale/timescaledb/releases/tag/2.7.1)
+* Upgrade TimescaleDB Toolkit extension to [1.8.0](https://github.com/timescale/timescaledb-toolkit/releases/tag/1.8.0)
+
 ## [v1.4.5] - 2022-06-23
 
 * Upgrade Promscale extension to 0.5.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -258,7 +258,7 @@ COPY build_scripts /build/scripts
 
 # If a specific GITHUB_TAG is provided, we will build that tag only. Otherwise
 # we build all the public (recent) releases
-RUN TS_VERSIONS="1.7.5 2.1.0 2.1.1 2.2.0 2.2.1 2.3.0 2.3.1 2.4.0 2.4.1 2.4.2 2.5.0 2.5.1 2.5.2 2.6.0 2.6.1 2.7.0" \
+RUN TS_VERSIONS="1.7.5 2.1.0 2.1.1 2.2.0 2.2.1 2.3.0 2.3.1 2.4.0 2.4.1 2.4.2 2.5.0 2.5.1 2.5.2 2.6.0 2.6.1 2.7.0 2.7.1" \
     && if [ "${GITHUB_TAG}" != "" ]; then TS_VERSIONS="${GITHUB_TAG}"; fi \
     && cd /build/timescaledb && git pull \
     && set -e \


### PR DESCRIPTION
## [v1.4.6] - 2022-07-07

* Include and default to [TimescaleDB 2.7.1](https://github.com/timescale/timescaledb/releases/tag/2.7.1)
* Upgrade TimescaleDB Toolkit extension to [1.8.0](https://github.com/timescale/timescaledb-toolkit/releases/tag/1.8.0)

