### PR TITLE
Revert "Stamp 1.4.7"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ These are changes that will probably be included in the next release.
 
 ## [future release]
 
-## [v1.4.7] - 2022-07-14
-
 * Upgrade Promscale extension to 0.5.3
 
 


### PR DESCRIPTION
Reverts timescale/timescaledb-docker-ha#281

As 1.4.7 was already tagged in a previous commit, I'll temporarily revert this before we decide how we proceed from here.
We need to either stamp 1.4.8 and update the changelog retroactively or something else.
Waiting on input from the team.