### PR TITLE
Feike/ts290

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ These are changes that will probably be included in the next release.
 
 ## [future release]
 
+## [v1.5.19] - 2022-12-19
+
+* Include Toolkit [1.13.0](https://github.com/timescale/timescaledb-toolkit/releases/tag/1.13.0)
+* Include and default to [TimescaleDB 2.9.0](https://github.com/timescale/timescaledb/releases/tag/2.9.0)
+* Reduce surface area for [leaking passwords](https://github.com/timescale/timescaledb-docker-ha/pull/338)
+
 ## [v1.5.18] - 2022-12-05
 
 * Include ts\_stat\_statements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ These are changes that will probably be included in the next release.
 
 ## [v1.5.18] - 2022-12-05
 
-* Include ts_stat_statements.
+* Include ts\_stat\_statements.
 
 ## [v1.5.17] - 2022-11-21
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -280,7 +280,7 @@ COPY build_scripts /build/scripts
 
 # If a specific GITHUB_TAG is provided, we will build that tag only. Otherwise
 # we build all the public (recent) releases
-RUN TS_VERSIONS="1.7.5 2.1.0 2.1.1 2.2.0 2.2.1 2.3.0 2.3.1 2.4.0 2.4.1 2.4.2 2.5.0 2.5.1 2.5.2 2.6.0 2.6.1 2.7.0 2.7.1 2.7.2 2.8.0 2.8.1" \
+RUN TS_VERSIONS="1.7.5 2.1.0 2.1.1 2.2.0 2.2.1 2.3.0 2.3.1 2.4.0 2.4.1 2.4.2 2.5.0 2.5.1 2.5.2 2.6.0 2.6.1 2.7.0 2.7.1 2.7.2 2.8.0 2.8.1 2.9.0" \
     && if [ "${GITHUB_TAG}" != "" ]; then TS_VERSIONS="${GITHUB_TAG}"; fi \
     && cd /build/timescaledb && git pull \
     && set -e \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # TimescaleDB Docker image for Kubernetes
+
 This directory contains everything that allows us to create a Docker image with the following pieces of software:
 
 - PostgreSQL
@@ -9,9 +10,10 @@ This directory contains everything that allows us to create a Docker image with 
 
 Currently, our base image is Ubuntu, as we require glibc 2.33+.
 
-# Build images
+## Build images
 
 To build an image, run the following make target:
+
 ```console
 make
 ```
@@ -21,12 +23,13 @@ The head of the `master` branch of the github.com/timescale/timescaledb.
 
 For more robust build runs do:
 
-```
+```console
 make build
 ```
 
 Or, if you only want to exclude Timescale License code you can use the following command:
-```
+
+```console
 make build-oss
 ```
 
@@ -42,34 +45,39 @@ POSTGIS_VERSIONS="" make build
 
 For further environment variables that can be set, we point you to the [Makefile](Makefile) itself.
 
-# Verify your work
+## Verify your work
 
 For every pushed commit to this repository, a Docker Image will be built and is available at a private
 Amazon Elastic Container Registry (ECR).
 
-## Find the image tag for your commit
+### Find the image tag for your commit
 
 > Replace *** with the AWS Account ID.
 
 Once your commit is pushed, a Docker Image will be built, and if successful, will be pushed.
 The tag of this Docker Image will be `cicd-<first 8 chars of commit sha>`, for example, for commit `baddcafe...`, the tag will look like:
 
-    ***.dkr.ecr.us-east-1.amazonaws.com/timescaledb-ha:cicd-deadbeef
+```text
+***.dkr.ecr.us-east-1.amazonaws.com/timescaledb-ha:cicd-deadbeef
+```
 
-### Find out tag using commandline
+#### Find out tag using commandline
+
 Assuming your current working directory is on the same commit as the one you pushed
+
 ```console
 echo "***.dkr.ecr.us-east-1.amazonaws.com/timescaledb-ha:cicd-$(git rev-parse HEAD | cut -c 1-8)"
 ```
 
-### Find tag using GitHub Web interface
+#### Find tag using GitHub Web interface
 
 - Actions
 - Click on the **Build Image** Workflow for your commit/branch
 - Expand **List docker Images**
 
-*Example output*
-```
+##### Example output
+
+```console
 Run make list-images
 docker images --filter [...]
 REPOSITORY                                           TAG             IMAGE ID       CREATED          SIZE
@@ -78,18 +86,20 @@ REPOSITORY                                           TAG             IMAGE ID   
 
 In the above example, your Docker tag is `cicd-d20dc5c5` and your full image url is:
 
-    ***.dkr.ecr.us-east-1.amazonaws.com/timescaledb-ha:cicd-d20dc5c5
-
+```text
+***.dkr.ecr.us-east-1.amazonaws.com/timescaledb-ha:cicd-d20dc5c5
+```
 
 ## Test your Docker Image
+
 ```console
 aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin ***.dkr.ecr.us-east-1.amazonaws.com
 docker run --rm -ti -e POSTGRES_PASSWORD=smoketest ***.dkr.ecr.us-east-1.amazonaws.com/timescaledb-ha:cicd-baddcafe
 ```
 
-# Versioning and Releases
+## Versioning and Releases
 
-## Release Process
+### Release Process
 
 Between releases we keep track of notable changes in CHANGELOG.md.
 
@@ -101,13 +111,17 @@ We should also copy the release notes to the Github releases page, but CHANGELOG
 
 The release commit should be tagged with a signed tag:
 
-    git tag -s vx.x.x
-    git push --tags
+```console
+git tag -s vx.x.x
+git push --tags
+```
 
 If you use the release notes in the tag commit message and it will automatically appear in the Github release. On the Github releases
 page click `Draft a new release` and then type your tag in the drop down contain `@master`. The release will automatically be created
 using the tag commit text.
-## Publish the images to Docker Hub and other registries
+
+### Publish the images to Docker Hub and other registries
+
 Only if you push a tag starting with `v`, for example: `v0.8.3` to the GitHub repository, will new images will be published to docker hub automatically.
 
 They will be written under quite a few aliases, for example, for PostgreSQL 12.6 and Timescale 2.0.1, the following images will be built and pushed/overwritten:
@@ -120,4 +134,5 @@ They will be written under quite a few aliases, for example, for PostgreSQL 12.6
 > the `-latest` suffix here indicates the latest docker build, not the latest commit. In particular, images built from a tag will be published with the `-latest` suffix in addition to the tag-based suffix.
 
 In addition, for every build, an immutable image will be created and pushed, which will carry a patch version at the end. These are most suited for production releases, for example:
+
 - timescale/timescaledb-ha:pg12.6-ts2.0.1-p0


### PR DESCRIPTION
# Stamp release v1.5.19

* Include Toolkit [1.13.0](https://github.com/timescale/timescaledb-toolkit/releases/tag/1.13.0)
* Include and default to [TimescaleDB 2.9.0](https://github.com/timescale/timescaledb/releases/tag/2.9.0)
* Reduce surface area for [leaking passwords](https://github.com/timescale/timescaledb-docker-ha/pull/338)


# Lint Markdown files

# Defaults to TimescaleDB 2.9.0

# Update rust 1.60.0 -> 1.65.0