### PR TITLE
allow build-time specification of UID/GID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,11 @@ ARG PG_MAJOR=13
 ## installed using external repositories.
 FROM ubuntu:22.04 AS compiler
 
-ENV PG_UID=1234
-ENV PG_GID=1234
+ARG PG_UID_ARG=1000
+ARG PG_GID_ARG=1000
+
+ENV PG_UID=$PG_UID_ARG
+ENV PG_GID=$PG_GID_ARG
 
 ENV DEBIAN_FRONTEND=noninteractive
 # We need full control over the running user, including the UID, therefore we

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,14 @@ ARG PG_MAJOR=13
 ## installed using external repositories.
 FROM ubuntu:22.04 AS compiler
 
+ENV PG_UID=1234
+ENV PG_GID=1234
+
 ENV DEBIAN_FRONTEND=noninteractive
 # We need full control over the running user, including the UID, therefore we
 # create the postgres user as the first thing on our list
-RUN adduser --home /home/postgres --uid 1000 --disabled-password --gecos "" postgres
+RUN adduser --home /home/postgres --uid $PG_UID --disabled-password --gecos "" postgres
+RUN groupmod -g $PG_GID postgres
 
 RUN echo 'APT::Install-Recommends "false";' >> /etc/apt/apt.conf.d/01norecommend
 RUN echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf.d/01norecommend

--- a/Makefile
+++ b/Makefile
@@ -100,9 +100,9 @@ DOCKER_BUILD_COMMAND=docker build --progress=plain \
 DOCKER_EXEC_COMMAND=docker exec -i $(DOCKER_TAG_PREPARE) timeout 90
 
 # We provide the fast target as the first (=default) target, as it will skip installing
-# many optional extensions, and it will only install a single timescaledb (master) version.
+# many optional extensions, and it will only install a single timescaledb (main) version.
 # This is basically useful for developers of this repository, to allow fast feedback cycles.
-fast: DOCKER_EXTRA_BUILDARGS= --build-arg GITHUB_TAG=master
+fast: DOCKER_EXTRA_BUILDARGS= --build-arg GITHUB_TAG=main
 fast: PG_AUTH_MON=
 fast: PG_LOGERRORS=
 fast: PG_VERSIONS=14


### PR DESCRIPTION
This issue comes up when you're trying to use a volume map and the host doesn't happen to have postgres:postgres on 1000:1000.  Using this patch you can specify an alternate build-time UID and GID.

Also fixes the fact that `master` was renamed to `main`.