### PR TITLE
Don't fail if we can't chown/chmod

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -93,15 +93,15 @@ docker_create_db_directories() {
 	if [ -n "${POSTGRES_INITDB_WALDIR:-}" ]; then
 		mkdir -p "$POSTGRES_INITDB_WALDIR"
 		if [ "$uid" -eq 0 ]; then
-			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
+			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' + || :
 		fi
-		chmod 700 "$POSTGRES_INITDB_WALDIR"
+		chmod 700 "$POSTGRES_INITDB_WALDIR" || :
 	fi
 
 	# allow the container to be started with `--user`
 	if [ "$uid" -eq 0 ]; then
-		find "$PGDATA" \! -user postgres -exec chown postgres: '{}' +
-		find /var/run/postgresql \! -user postgres -exec chown postgres: '{}' +
+		find "$PGDATA" \! -user postgres -exec chown postgres: '{}' + || :
+		find /var/run/postgresql \! -user postgres -exec chown postgres: '{}' + || :
 	fi
 }
 


### PR DESCRIPTION
On Windows (or other filesystems that don't like chown/chmod) this might not work, but that doesn't mean we don't want to try to execute postgres.

Hopefully fixes #334