### PR TITLE
Remove DCS failsafe Patroni fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -157,22 +157,6 @@ RUN set -eux; \
 # This need to be done after the PostgreSQL packages have been installed,
 # to ensure we have the preferred libpq installations etc.
 RUN apt-get install -y python3-etcd python3-requests python3-pystache python3-kubernetes python3-pysyncobj patroni
-
-# Patch Patroni code with changes from https://github.com/zalando/patroni/pull/2379.
-# NOTE: This is a temporary solution until changes land upstream.
-ARG TIMESCALE_DCS_FAILSAFE
-RUN if [ -n "${TIMESCALE_DCS_FAILSAFE}" ]; then \
-        mkdir /tmp/patroni; \
-        cd /tmp/patroni; \
-        git init; \
-        git remote add -f origin https://github.com/timescale/patroni.git; \
-        git config core.sparseCheckout true; \
-        echo 'patroni' > .git/info/sparse-checkout; \
-        git pull origin dcs-failsafe-mode; \
-        rm -rf /usr/lib/python3/dist-packages/patroni; \
-        mv /tmp/patroni/patroni /usr/lib/python3/dist-packages; \
-    fi
-
 RUN apt-get install -y timescaledb-tools
 
 ## Entrypoints as they are from the Timescale image and its default upstream repositories.

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ PGVECTOR?=v0.4.1
 TIMESCALEDB_VERSIONS?=all
 PROMSCALE_VERSIONS?=all
 TOOLKIT_VERSIONS?=all
-TIMESCALE_DCS_FAILSAFE?=true
 
 # This is used to build the docker --platform, so pick amd64 or arm64
 PLATFORM?=amd64
@@ -121,7 +120,6 @@ DOCKER_BUILD_COMMAND=docker build \
 					 --build-arg PROMSCALE_VERSIONS="$(PROMSCALE_VERSIONS)" \
 					 --build-arg TOOLKIT_VERSIONS="$(TOOLKIT_VERSIONS)" \
 					 --build-arg PGVECTOR="$(PGVECTOR)" \
-					 --build-arg TIMESCALE_DCS_FAILSAFE="$(TIMESCALE_DCS_FAILSAFE)" \
 					 --build-arg RELEASE_URL="$(DOCKER_RELEASE_URL)" \
 					 --build-arg BUILDER_URL="$(DOCKER_BUILDER_URL)" \
 					 --label com.timescaledb.image.install_method=$(INSTALL_METHOD) \


### PR DESCRIPTION
Since DCS failsafe has been merged into Patroni v3, there is no need for custom-patching it. Moreover, our own branch reverts some changes expected in v3, namely, changes a primary_start_timeout parameter name back to master_start_timeout.