### PR TITLE
Add toolkit 1.17.0

### DIFF
--- a/build_scripts/install_extensions
+++ b/build_scripts/install_extensions
@@ -3,11 +3,11 @@
 SCRIPT_DIR="${BASH_SOURCE[0]%/*}"
 . "$SCRIPT_DIR"/shared.sh
 
-# This takes the requested toolkit and promscale extensions, figures out what versions of cargo-pgx those
-# versions want, and then build from the oldest pgx to the newest so that `cargo install cargo-pgx --version`
-# commands are only ran once. Once cargo-pgx has been installed, run the installation for the extensions,
-# and then continue through the next cargo-pgx version. At the end, we're left with the latest version of
-# cargo-pgx so that the builder image can be used to test master/main branches.
+# This takes the requested toolkit and promscale extensions, figures out what versions of cargo-pgx/pgrx those
+# versions want, and then build from the oldest pgx/pgrx to the newest so that `cargo install cargo-pgx/pgrx --version`
+# commands are only ran once. Once cargo-pgrx has been installed, run the installation for the extensions,
+# and then continue through the next cargo-pgrx version. At the end, we're left with the latest version of
+# cargo-pgrx so that the builder image can be used to test master/main branches.
 
 # we use the following variables to decide on if/what to install:
 # - PROMSCALE_VERSIONS

--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -1,13 +1,15 @@
 # We need to describe various things for each version of each extension:
-# 1. which version of cargo-pgx is required
+# 1. which version of cargo-pgrx is required
 # 2. which version of pg is supported
 
 # extension:
 #   version:
 #     key/values
-# 
-# Specify which version of cargo-pgx is required for this extension:
-# cargo-pgx: <version> 
+#
+# Specify which version of cargo-pgrx is required for this extension
+# versions < 0.8.0 were called pgx, but the scripts automatically pick
+# the correct name based on the version.
+# cargo-pgrx: <version>
 #
 # Specify which version of postgresql this version supports:
 # pg-min: <version>  (defaults to 12 if not specified)
@@ -16,7 +18,6 @@
 
 default-pg-min: 12
 default-pg-max: 15
-default-cargo-pgx: 0.6.1
 
 timescaledb:
   1.7.5:
@@ -77,51 +78,57 @@ timescaledb:
 promscale:
   0.5.0:
     pg-max: 14
-    cargo-pgx: 0.3.1
+    cargo-pgrx: 0.3.1
   0.5.1:
     pg-max: 14
-    cargo-pgx: 0.3.1
+    cargo-pgrx: 0.3.1
   0.5.2:
     pg-max: 14
-    cargo-pgx: 0.3.1
+    cargo-pgrx: 0.3.1
   0.5.4:
     pg-max: 14
-    cargo-pgx: 0.3.1
+    cargo-pgrx: 0.3.1
   0.6.0:
     pg-max: 14
-    cargo-pgx: 0.4.5
+    cargo-pgrx: 0.4.5
   0.7.0:
     pg-max: 14
-    cargo-pgx: 0.4.5
+    cargo-pgrx: 0.4.5
   0.8.0:
+    cargo-pgrx: 0.6.1
 
 toolkit:
   1.6.0:
     pg-max: 14
-    cargo-pgx: 0.2.4
+    cargo-pgrx: 0.2.4
   1.7.0:
     pg-max: 14
-    cargo-pgx: 0.2.4
+    cargo-pgrx: 0.2.4
   1.8.0:
     pg-max: 14
-    cargo-pgx: 0.4.5
+    cargo-pgrx: 0.4.5
   1.10.1:
     pg-max: 14
-    cargo-pgx: 0.4.5
+    cargo-pgrx: 0.4.5
   1.11.0:
     pg-max: 14
-    cargo-pgx: 0.4.5
+    cargo-pgrx: 0.4.5
   1.12.0:
     pg-max: 14
-    cargo-pgx: 0.5.4
+    cargo-pgrx: 0.5.4
   1.12.1:
     pg-max: 14
-    cargo-pgx: 0.5.4
+    cargo-pgrx: 0.5.4
   1.13.0:
     pg-max: 14
+    cargo-pgrx: 0.6.1
   1.13.1:
+    cargo-pgrx: 0.6.1
   1.14.0:
+    cargo-pgrx: 0.6.1
   1.15.0:
-    cargo-pgx: 0.7.1
+    cargo-pgrx: 0.7.1
   1.16.0:
-    cargo-pgx: 0.7.1
+    cargo-pgrx: 0.7.1
+  1.17.0:
+    cargo-pgrx: 0.9.7


### PR DESCRIPTION
This also adds support for the renamed pgx -> pgrx from version 0.8.0+, and also removes the default-cargo-pgx key in versions.yaml since almost every extension version needs a different version anyway.

This automatically picks using pgx or pgrx based on the requested version.