### PR TITLE
feat: execute perms for replication

### DIFF
--- a/scripts/timescaledb/after-create.sql
+++ b/scripts/timescaledb/after-create.sql
@@ -24,3 +24,14 @@ BEGIN
         END LOOP;
 END$$;
 
+-- Grant pg_replication permissions to tsdbadmin to allow logical decoding.
+DO $$DECLARE r record;
+BEGIN
+    FOR r IN SELECT func from unnest(ARRAY[
+            'pg_replication_origin_oid(text)', 'pg_replication_origin_create(text)', 'pg_replication_origin_advance(text, pg_lsn)',
+            'pg_replication_origin_progress(text, boolean)', 'pg_replication_origin_drop(text)', 'pg_replication_origin_session_setup(text)',
+            'pg_replication_origin_xact_setup(pg_lsn, timestamp with time zone)']) tsch
+        LOOP
+            EXECUTE 'GRANT EXECUTE ON FUNCTION ' || r.func || ' TO @database_owner@';
+        END LOOP;
+END$$;


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

Refers: https://github.com/timescale/forge-issues/issues/908

This commit adds `EXECUTE` permission on `pg_replication_origin_.*` functions to `tsdbadmin`. This enables data-ingest team to work on logical-decoding with an aim to provide a low-downtime data migration system.