### PR TITLE
Run make clean in some extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,7 +153,7 @@ RUN set -eux; \
             postgresql-${pg}-pgrouting postgresql-${pg}-repack postgresql-${pg}-hypopg postgresql-${pg}-unit \
             postgresql-${pg}-pg-stat-kcache postgresql-${pg}-cron postgresql-${pg}-pldebugger postgresql-${pg}-pgpcre \
             postgresql-${pg}-pglogical postgresql-${pg}-wal2json postgresql-${pg}-pgq3 postgresql-${pg}-pg-qualstats \
-            postgresql-${pg}-pgaudit postgresql-${pg}-ip4r postgresql-${pg}-pgtap postgresql-${pg}-orafce" ; \
+            postgresql-${pg}-pgaudit postgresql-${pg}-ip4r postgresql-${pg}-pgtap postgresql-${pg}-orafce"; \
     done; \
     apt-get install -y $packages
 
@@ -268,7 +268,7 @@ RUN set -ex; \
         git checkout "${PG_STAT_MONITOR}"; \
         for pg in ${PG_VERSIONS}; do \
             git reset HEAD --hard; \
-            PATH="/usr/lib/postgresql/${pg}/bin:${PATH}" make USE_PGXS=1 all; \
+            PATH="/usr/lib/postgresql/${pg}/bin:${PATH}" make USE_PGXS=1 clean; \
             PATH="/usr/lib/postgresql/${pg}/bin:${PATH}" make USE_PGXS=1 install; \
         done; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -289,7 +289,7 @@ RUN set -ex; \
         git checkout "${PGVECTOR}"; \
         for pg in ${PG_VERSIONS}; do \
             git reset HEAD --hard; \
-            PATH="/usr/lib/postgresql/${pg}/bin:${PATH}" make OPTFLAGS="" all; \
+            PATH="/usr/lib/postgresql/${pg}/bin:${PATH}" make OPTFLAGS="" clean; \
             PATH="/usr/lib/postgresql/${pg}/bin:${PATH}" make OPTFLAGS="" install; \
         done; \
     fi


### PR DESCRIPTION
We do `git reset HEAD --hard`, but it doesn't remove untracked files,
making a subsequent builds a no-op. Since we want to actually build
an extension anew for different postgres versions, run `make clean`.