### PR TITLE
Configure 2.13.1 build

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -84,6 +84,9 @@ timescaledb:
   2.13.0:
     pg-min: 13
     pg-max: 16
+  2.13.1:
+    pg-min: 13
+    pg-max: 16
 
 promscale:
   0.5.0:


### PR DESCRIPTION
Build TimescaleDB 2.13.1 
https://github.com/timescale/timescaledb/releases/tag/2.13.1