### PR TITLE
arm64 builds!

### DIFF
--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -15,7 +15,6 @@ concurrency:
 env:
   DOCKER_REPOSITORY: timescale/timescaledb-ha
   DOCKER_REGISTRY: docker.io
-  PLATFORM: amd64
   PG_MAJOR: 16
   ALL_VERSIONS: "true"
   OSS_ONLY: "false"
@@ -23,6 +22,68 @@ env:
 jobs:
   build-branch:
     name: Build and push branch
+    runs-on: ${{ matrix.runs_on }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ amd64, arm64 ]
+        include:
+          - platform: amd64
+            runs_on: ubuntu-22.04
+          - platform: arm64
+            runs_on: cloud-image-runner-arm64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install docker (arm64 beta)
+        if: matrix.platform == 'arm64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl acl build-essential
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+          sudo usermod -aG docker $USER
+          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.ORG_DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.ORG_DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Setup | Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: make build-sha
+
+      - name: Check
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: make check-sha
+
+      - name: Publish
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: make publish-sha
+
+  publish-combined-manifest:
+    name: Publish branch manifest
+    needs: [ "build-branch" ]
     runs-on: ubuntu-latest
 
     steps:
@@ -35,14 +96,5 @@ jobs:
           username: ${{ secrets.ORG_DOCKER_HUB_USERNAME }}
           password: ${{ secrets.ORG_DOCKER_HUB_ACCESS_TOKEN }}
 
-      - name: Setup | Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build
-        run: make build-sha
-
-      - name: Check
-        run: make check-sha
-
-      - name: Publish
-        run: make publish-sha
+      - name: Publish combined manifest for branch
+        run: make publish-combined-sha

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - master
+      - main
     paths-ignore:
       - "*.md"
 
@@ -22,12 +23,12 @@ env:
 
 jobs:
   publish:
-    name: Publish pg${{ matrix.pg_major }}${{ matrix.all }}${{ matrix.oss }}
+    name: Publish pg${{ matrix.pg_major }}${{ matrix.all }}${{ matrix.oss }} ${{ matrix.platform }}
 
     strategy:
       fail-fast: false
       matrix:
-        platform: [ "amd64" ]
+        platform: [ "amd64", "arm64" ]
         pg_major: [ "16", "15", "14", "13", "12" ]
         all_versions: [ "false", "true" ]
         oss_only: [ "false", "true" ]
@@ -37,12 +38,35 @@ jobs:
             oss: "-oss"
           - all_versions: "true"
             all: "-all"
+          - platform: amd64
+            runs_on: ubuntu-22.04
+          - platform: arm64
+            runs_on: cloud-image-runner-arm64
 
-    runs-on: ubuntu-latest
+    runs-on: "${{ matrix.runs_on }}"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Install docker (arm64 beta)
+        if: matrix.platform == 'arm64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates curl acl build-essential
+          sudo install -m 0755 -d /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+            sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+          sudo usermod -aG docker $USER
+          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -58,7 +82,7 @@ jobs:
         with:
           endpoint: ha-builder
 
-      - name: Build and publish (pg${{ matrix.pg_major }}${{ matrix.all }}${{ matrix.oss }})
+      - name: Build and publish (pg${{ matrix.pg_major }}${{ matrix.all }}${{ matrix.oss }} ${{ matrix.platform }})
         env:
           PLATFORM: ${{ matrix.platform }}
           PG_MAJOR: ${{ matrix.pg_major }}
@@ -80,11 +104,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.ORG_DOCKER_HUB_USERNAME }}
           password: ${{ secrets.ORG_DOCKER_HUB_ACCESS_TOKEN }}
+
+      # QEMU for multiplatform, which should be quick enough for pulling version information out of the images
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Publish combined manifest for pg${{ matrix.pg_major }}${{ matrix.docker_tag_postfix }}
         env:
           PG_MAJOR: ${{ matrix.pg_major }}
@@ -111,6 +141,10 @@ jobs:
         with:
           username: ${{ secrets.ORG_DOCKER_HUB_USERNAME }}
           password: ${{ secrets.ORG_DOCKER_HUB_ACCESS_TOKEN }}
+
+      # QEMU for multiplatform, which should be quick enough for just the checks
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Check pg${{ matrix.pg_major }}${{ matrix.docker_tag_postfix }}
         env:

--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -15,9 +15,13 @@
 # pg-min: <version>  (defaults to 12 if not specified)
 # pg-max: <version>  (defaults to 15 if not specified)
 # pg: [ 12, 13, 14, 15 ] (pick specific versions to build this extension with)
+#
+# arch: <amd64|aarch64|both>
 
 default-pg-min: 12
 default-pg-max: 15
+default-cargo-pgx: 0.6.1
+default-arch: both
 
 timescaledb:
   1.7.5:
@@ -99,49 +103,64 @@ timescaledb:
 
 promscale:
   0.5.0:
+    arch: amd64
     pg-max: 14
     cargo-pgrx: 0.3.1
   0.5.1:
+    arch: amd64
     pg-max: 14
     cargo-pgrx: 0.3.1
   0.5.2:
+    arch: amd64
     pg-max: 14
     cargo-pgrx: 0.3.1
   0.5.4:
+    arch: amd64
     pg-max: 14
     cargo-pgrx: 0.3.1
   0.6.0:
+    arch: amd64
     pg-max: 14
     cargo-pgrx: 0.4.5
   0.7.0:
+    arch: amd64
     pg-max: 14
     cargo-pgrx: 0.4.5
   0.8.0:
+    arch: amd64
     cargo-pgrx: 0.6.1
 
 toolkit:
   1.6.0:
+    arch: amd64
     pg-max: 14
     cargo-pgrx: 0.2.4
   1.7.0:
+    arch: amd64
     pg-max: 14
     cargo-pgrx: 0.2.4
   1.8.0:
+    arch: amd64
     pg-max: 14
     cargo-pgrx: 0.4.5
   1.10.1:
+    arch: amd64
     pg-max: 14
     cargo-pgrx: 0.4.5
   1.11.0:
+    arch: amd64
     pg-max: 14
     cargo-pgrx: 0.4.5
   1.12.0:
+    arch: amd64
     pg-max: 14
     cargo-pgrx: 0.5.4
   1.12.1:
+    arch: amd64
     pg-max: 14
     cargo-pgrx: 0.5.4
   1.13.0:
+    arch: amd64
     pg-max: 14
     cargo-pgrx: 0.6.1
   1.13.1:

--- a/cicd/shared.sh
+++ b/cicd/shared.sh
@@ -133,6 +133,11 @@ check_promscale() {
         return
     fi
 
+    if [ "$ARCH" != amd64 ]; then
+        # no arm64 promscale packages
+        return
+    fi
+
     # record an empty version so we'll get an empty table row if we don't have any versions
     record_ext_version promscale_extension "$pg" ""
 


### PR DESCRIPTION
This uses the closed beta for linux/arm64 runners from github. Until they become generally available, the image used for the runners is missing _many_ tools (like make?!). This adds a step to install docker and build-essential (that includes make) when building the arm images.

There's also one commit that will be dropped before merging, and the timescaledev docker hub reference would be changed to just timescale as well.