### PR TITLE
Bug Fix: Missing Barman Cloud entrypoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -230,7 +230,8 @@ RUN apt-get install -y python3-etcd python3-requests python3-pystache python3-ku
 
 # Barman cloud
 # Required for CloudNativePG compatibility
-RUN apt-get install -y python3-barman
+RUN apt-get install -y python3-pip && \
+    pip3 install --no-cache-dir 'barman[cloud,azure,snappy,google]'
 
 RUN apt-get install -y timescaledb-tools
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -146,6 +146,9 @@ RUN set -eux; \
     echo 'en_US.UTF-8 UTF-8' > /usr/share/i18n/SUPPORTED; \
     localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
+# We install pip3, as we need it for some of the extensions. This will install a lot of dependencies, all marked as auto to help with cleanup later
+RUN apt-get install -y python3 python3-pip
+
 # We install some build dependencies and mark the installed packages as auto-installed,
 # this will cause the cleanup to get rid of all of these packages
 ENV BUILD_PACKAGES="binutils cmake devscripts equivs gcc git gpg gpg-agent libc-dev libc6-dev libkrb5-dev libperl-dev libssl-dev lsb-release make patchutils python2-dev python3-dev wget libsodium-dev"
@@ -192,7 +195,7 @@ RUN set -ex; \
 
 # Add a couple 3rd party extension managers to make extension additions easier
 RUN set -eux; \
-    apt-get install -y pgxnclient 
+    apt-get install -y pgxnclient
 
 ## Add pgsodium extension depedencies
 RUN set -eux; \
@@ -230,8 +233,7 @@ RUN apt-get install -y python3-etcd python3-requests python3-pystache python3-ku
 
 # Barman cloud
 # Required for CloudNativePG compatibility
-RUN apt-get install -y python3-pip && \
-    pip3 install --no-cache-dir 'barman[cloud,azure,snappy,google]'
+RUN pip3 install --no-cache-dir 'barman[cloud,azure,snappy,google]'
 
 RUN apt-get install -y timescaledb-tools
 


### PR DESCRIPTION
In #442 I added the `python3-barman` package in anticipation for the `ImageCatalog` feature in CloudNativePG that would allow running the official Timescale image in CNPG.

That PR though has two issues:
1. Unlike `python-pip`, `apt-get` does not install package binaries, required for interaction with `barman-cloud`.
2. It did not add necessary dependencies for Azure and Google cloud support.

I tried implementing it without `python-pip`, but the Azure Storage package `python3-azure-storage` is over `600MB` which completely defeats the purpose of the size optimization. With `pip` the `barman` package only fetches `azure-blob-storage` and this results in around `300MB` smaller image, compared to the deb package only approach.

I suspect that once I add `python3-pip` it may be beneficial for other as well to switch to `pip` packages instead of Debian packages as:
* More targeted packages have a smaller size impact and less bloat
* Newer versions of packages are available via `pip`.

In fact if you request it, I will move the `apt-get install -y python3-pip` to the beginning of the Dockerfile so it is available to use earlier. I only kept it here so the Docker image is easier to build and use more cache.

P.S. Special thanks to @NiccoloFei for his assistance in debugging this.