### PR TITLE
Build TimescaleDB 2.15.2

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -106,6 +106,9 @@ timescaledb:
   2.15.1:
     pg-min: 13
     pg-max: 16
+  2.15.2:
+    pg-min: 13
+    pg-max: 16
 
 promscale:
   0.5.0:


### PR DESCRIPTION
Per https://github.com/timescale/timescaledb/releases/tag/2.15.2