### PR TITLE
Release TimescaleDB 2.15.3

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -109,6 +109,9 @@ timescaledb:
   2.15.2:
     pg-min: 13
     pg-max: 16
+  2.15.3:
+    pg-min: 13
+    pg-max: 16
 
 promscale:
   0.5.0:


### PR DESCRIPTION
Include and default to TimescaleDB 2.15.3