### PR TITLE
[Security] Fix stdlib CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -528,9 +528,9 @@ RUN set -ex; \
 
 USER postgres
 
-
 ## Create a smaller Docker image from the builder image
-FROM scratch as release
+FROM alpine:3.16.9 as release
+
 COPY --from=trimmed / /
 
 ARG PG_MAJOR


### PR DESCRIPTION
# Summary of changes

## Issue
When scanning `timescaledb-docker-ha` with Docker Scout, we find 3 critical and more than 20 high-severity CVEs, which originated from `scratch` latest image.

## Solution
To resolve the issue, we replace `scratch` base image with `alpine:3.16.9` which is free from critical and high CVEs.

## Results & Challenges 
The patch resolves the problem, but there is an issue with Dockerfile spec, especially line:
`COPY --from=trimmed / /`
This causes a conflict between files and directories during COPY operation in Docker.

I Suggest to define the necessary directories and files for timescaledb to be copied instead.

## Change Checklist

- [ ]  I have performed a self-review of my code.
- [ ] I have added tests that prove my fix is effective.
- [ ] I made sure the CHANGELOG is up-to-date.