### PR TITLE
Release timescaledb 2.16.1

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -115,6 +115,9 @@ timescaledb:
   2.16.0:
     pg-min: 14
     pg-max: 16
+  2.16.1:
+    pg-min: 14
+    pg-max: 16
 
 promscale:
   0.5.0:


### PR DESCRIPTION
https://github.com/timescale/timescaledb/releases/tag/2.16.1