### PR TITLE
Strip spaces around equals sign in pgrx config

### DIFF
--- a/build_scripts/shared.sh
+++ b/build_scripts/shared.sh
@@ -214,6 +214,8 @@ cargo_pgrx_init() {
         error "failed cargo $pgrx_cmd init ${args[*]} ($err)"
         return $err
     fi
+    # The build script in Toolkit versions <= 1.19.0 assumes that there aren't any spaces between pgXX and =
+    sed -i 's/ *= */=/g' /home/postgres/.$pgrx_cmd/config.toml
     return 0
 }
 


### PR DESCRIPTION
Newer `cargo pgrx init` can generate TOML files with spaces around the equals sign, but Toolkit can't handle that until we release https://github.com/timescale/timescaledb-toolkit/pull/833. This PR works around that by removing spaces around the equals sign in the generated TOML file.