### PR TITLE
Release TimescaleDB 2.18.0

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -127,6 +127,9 @@ timescaledb:
   2.17.2:
     pg-min: 14
     pg-max: 17
+  2.18.0:
+    pg-min: 14
+    pg-max: 17
 
 toolkit:
   1.6.0:


### PR DESCRIPTION
https://github.com/timescale/timescaledb/releases/tag/2.18.0