### PR TITLE
Use uv to install pgai dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,11 +149,8 @@ RUN set -eux; \
 # We install pip3, as we need it for some of the extensions. This will install a lot of dependencies, all marked as auto to help with cleanup later
 RUN apt-get install -y python3 python3-pip
 
-# pgai requires pip 23.0.1 or greater due to the use of --break-system-packages flag
-RUN set -ex; \
-    if [ "$(pip --version | awk '{print $2; exit}')" \< "23.0.1" ]; then \
-        python3 -m pip install --upgrade pip==23.0.1; \
-    fi;
+# using uv with pgai reduces size of dependencies
+RUN python3 -m pip install uv
 
 # We install some build dependencies and mark the installed packages as auto-installed,
 # this will cause the cleanup to get rid of all of these packages


### PR DESCRIPTION
pgai's `build.py install` will automatically use uv if it's available on the system path. When uv installs dependencies into a target directory, it uses hardlinks to a centralized cache. This allows a large number of dependencies to be reused across pgai versions.