### PR TITLE
pin pg versions

### DIFF
--- a/build_scripts/pg_version.sh
+++ b/build_scripts/pg_version.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+MAJOR="${1}"
+if [ -z "${MAJOR}" ]; then
+    echo "missing major version" 
+    exit 2
+fi
+
+PINNED=$(yq ".postgres_versions.${MAJOR}" /build/scripts/versions.yaml)
+if [ "${PINNED}" = "null" ]; then
+    echo "could not find ${MAJOR} pinned version" 
+    exit 2
+fi
+
+echo "${PINNED}"

--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -23,6 +23,16 @@ default-pg-max: 15
 default-cargo-pgx: 0.6.1
 default-arch: both
 
+## this contains the specific pg versions that will be installed.
+## from https://www.postgresql.org/about/news/postgresql-172-166-1510-1415-1318-and-1222-released-2965/
+postgres_versions:
+  17: 17.2
+  16: 16.6
+  15: 15.10
+  14: 14.15
+  13: 13.18
+  12: 12.22
+
 timescaledb:
   1.7.5:
     # in the previous -ha versions, pg12 has every timescaledb version


### PR DESCRIPTION
This PR pins the Postgres versions installed.

> [!NOTE]  
> I didn't bother about the build dependencies. Since it is not common to change dependencies on minor releases, I'm assuming that it is safe to use the latest minor to define the build deps.

Main changes in the PR:
* All versions are set in the `build_scripts/versions.yaml` file
* Added the PGDG archive repo