### PR TITLE
Use Rust 1.85

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,7 +119,7 @@ RUN sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/cr
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.82.0
+    RUST_VERSION=1.85.0
 
 RUN set -eux; \
     dpkgArch="$(dpkg --print-architecture)"; \


### PR DESCRIPTION
Main use case is to allow compilation of Rust 2024 edition projects.

https://doc.rust-lang.org/edition-guide/rust-2024/index.html