### PR TITLE
Add vectorscale 0.6.0

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -214,3 +214,6 @@ pgvectorscale:
   0.5.1:
     pg-min: 13
     pg-max: 17
+  0.6.0:
+    pg-min: 13
+    pg-max: 17


### PR DESCRIPTION
This [was released](https://github.com/timescale/pgvectorscale/releases/tag/0.6.0) on Friday last week.