### PR TITLE
feat: Add pg_semver extension to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -186,7 +186,7 @@ RUN set -eux; \
             postgresql-${pg}-pgrouting postgresql-${pg}-repack postgresql-${pg}-hypopg postgresql-${pg}-unit \
             postgresql-${pg}-pg-stat-kcache postgresql-${pg}-cron postgresql-${pg}-pldebugger postgresql-${pg}-pgpcre \
             postgresql-${pg}-pglogical postgresql-${pg}-wal2json postgresql-${pg}-pgq3 postgresql-${pg}-pg-qualstats \
-            postgresql-${pg}-pgaudit postgresql-${pg}-ip4r postgresql-${pg}-pgtap postgresql-${pg}-orafce \
+            postgresql-${pg}-pgaudit postgresql-${pg}-ip4r postgresql-${pg}-pgtap postgresql-${pg}-semver postgresql-${pg}-orafce \
             postgresql-${pg}-pgvector postgresql-${pg}-h3 postgresql-${pg}-rum"; \
     done; \
     apt-get install -y $packages


### PR DESCRIPTION
pg_semver is from the same author as pg_tap and adds a semantic version type to postgres, and is distributed as part of the postgres apt repository.


It is technically possible to use a string column for this by enabling natural sorting at the unicode locale level with a collation, and by enabling regex validation to prevent git hashes from polluting the column and from introducing worst case times for unicode natural sorting. But pg_semver's representation is much more efficient and easier to introduce & enforce in practice if the extension is easily available.

This does add a small amount of bloat to the image (self-contained .so file and the plpgsql glue), so feel free to reject for any reason.