### PR TITLE
Remove pg12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -560,10 +560,10 @@ ENV PGROOT=/home/postgres \
 # Shutdown mode" in which any existing sessions are allowed to finish and the
 # server stops when all sessions are terminated.
 #
-# See https://www.postgresql.org/docs/12/server-shutdown.html for more details
+# See https://www.postgresql.org/docs/17/server-shutdown.html for more details
 # about available PostgreSQL server shutdown signals.
 #
-# See also https://www.postgresql.org/docs/12/server-start.html for further
+# See also https://www.postgresql.org/docs/17/server-start.html for further
 # justification of this as the default value, namely that the example (and
 # shipped) systemd service files use the "Fast Shutdown mode" for service
 # termination.
@@ -576,7 +576,7 @@ STOPSIGNAL SIGINT
 # STOPSIGNAL and sending SIGKILL (which is likely to cause data corruption).
 #
 # The default in most runtimes (such as Docker) is 10 seconds, and the
-# documentation at https://www.postgresql.org/docs/12/server-start.html notes
+# documentation at https://www.postgresql.org/docs/17/server-start.html notes
 # that even 90 seconds may not be long enough in many instances.
 
 WORKDIR /home/postgres

--- a/Makefile
+++ b/Makefile
@@ -42,17 +42,17 @@ endif
 ifeq ($(ALL_VERSIONS),true)
   DOCKER_TAG_POSTFIX := $(strip $(DOCKER_TAG_POSTFIX))-all
   ifeq ($(PG_MAJOR),17)
-    PG_VERSIONS := 17 16 15 14 13 12
+    PG_VERSIONS := 17 16 15 14 13
   else ifeq ($(PG_MAJOR),16)
-    PG_VERSIONS := 16 15 14 13 12
+    PG_VERSIONS := 16 15 14 13
   else ifeq ($(PG_MAJOR),15)
-    PG_VERSIONS := 15 14 13 12
+    PG_VERSIONS := 15 14 13
   else ifeq ($(PG_MAJOR),14)
-    PG_VERSIONS := 14 13 12
+    PG_VERSIONS := 14 13
   else ifeq ($(PG_MAJOR),13)
-    PG_VERSIONS := 13 12
+    PG_VERSIONS := 13
   else ifeq ($(PG_MAJOR),12)
-    PG_VERSIONS := 12
+  	$(error pg12 is no longer supported)
   endif
 else
   PG_VERSIONS := $(PG_MAJOR)
@@ -116,10 +116,10 @@ VERSION_IMAGE := $(DOCKER_PUBLISH_URL):$(VERSION_TAG)
 # The purpose of publishing the images under many tags, is to provide
 # some choice to the user as to their appetite for volatility.
 #
-#  1. timescale/timescaledb-ha:pg12
-#  2. timescale/timescaledb-ha:pg12-ts1.7
-#  3. timescale/timescaledb-ha:pg12.3-ts1.7
-#  4. timescale/timescaledb-ha:pg12.3-ts1.7.1
+#  1. timescale/timescaledb-ha:pg17
+#  2. timescale/timescaledb-ha:pg17-ts2.19
+#  3. timescale/timescaledb-ha:pg17.3-ts2.19
+#  4. timescale/timescaledb-ha:pg17.3-ts2.19.0
 
 $(VERSION_INFO):
 	docker rm --force builder_inspector >&/dev/null || true

--- a/README.md
+++ b/README.md
@@ -135,5 +135,5 @@ For `OSS_ONLY` builds, the following tags will be published:
 - timescale/timescaledb-ha:pg15.2-ts2.10.3-oss
 - timescale/timescaledb-ha:pg15.2-ts2.10.3-all-oss
 
-The `-all` portion of the tags specifies that the image contains pg15, as well as version 12, 13, and 14. Otherwise, only
+The `-all` portion of the tags specifies that the image contains pg15, as well as version 13, and 14. Otherwise, only
 the single version of PostgreSQL is included in the image.

--- a/build_scripts/shared.sh
+++ b/build_scripts/shared.sh
@@ -168,7 +168,7 @@ require_cargo_pgrx_version() {
 available_pg_versions() {
     # this allows running out-of-container with dry-run to test script logic
     if [[ "$DRYRUN" = true && ! -d /usr/lib/postgresql ]]; then
-        echo 12 13 14 15 16 17
+        echo 13 14 15 16 17
     else
         (cd /usr/lib/postgresql && ls)
     fi

--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -12,19 +12,19 @@
 # cargo-pgrx: <version>
 #
 # Specify which version of postgresql this version supports:
-# pg-min: <version>  (defaults to 12 if not specified)
+# pg-min: <version>  (defaults to 13 if not specified)
 # pg-max: <version>  (defaults to 15 if not specified)
-# pg: [ 12, 13, 14, 15 ] (pick specific versions to build this extension with)
+# pg: [ 13, 14, 15 ] (pick specific versions to build this extension with)
 #
 # arch: <amd64|aarch64|both>
 
-default-pg-min: 12
+default-pg-min: 13
 default-pg-max: 15
 default-cargo-pgx: 0.6.1
 default-arch: both
 
 ## This session contains the specific pg versions that will be installed.
-## Please notice that pg 12 is EOL now and has no more updates.
+## Please notice that pg 12 is EOL now and has no more updates, which is why it was removed:
 ## from https://www.postgresql.org/about/news/postgresql-174-168-1512-1417-and-1320-released-3018/
 postgres_versions:
   17: 17.4
@@ -32,17 +32,10 @@ postgres_versions:
   15: 15.12
   14: 14.17
   13: 13.20
-  12: 12.22
 
 timescaledb:
-  1.7.5:
-    # in the previous -ha versions, pg12 has every timescaledb version
-    pg-max: 12
   2.1.0:
-    # in the previous -ha versions, pg13 has 2.x+
-    #pg-max: 13
-    # using pg: for testing
-    pg: [12, 13]
+    pg: [13]
   2.1.1:
     pg-max: 13
   2.2.0:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -269,7 +269,7 @@ pg_setup_hba_conf() {
 		printf '\n'
 		if [ 'trust' = "$POSTGRES_HOST_AUTH_METHOD" ]; then
 			printf '# warning trust is enabled for all connections\n'
-			printf '# see https://www.postgresql.org/docs/12/auth-trust.html\n'
+			printf '# see https://www.postgresql.org/docs/17/auth-trust.html\n'
 		fi
 		printf 'host all all all %s\n' "$POSTGRES_HOST_AUTH_METHOD"
 	} >> "$PGDATA/pg_hba.conf"


### PR DESCRIPTION
It's no longer supported, and won't get any further updates. If you need to upgrade from pg12, use a previous tag of this repository to perform the upgrade prior to switching to the newest builds.