### PR TITLE
Build TimescaleDB 2.19.1

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -143,6 +143,9 @@ timescaledb:
   2.19.0:
     pg-min: 14
     pg-max: 17
+  2.19.1:
+    pg-min: 14
+    pg-max: 17
 
 toolkit:
   1.17.0:


### PR DESCRIPTION
https://github.com/timescale/timescaledb/releases/tag/2.19.1