### PR TITLE
Add vectorscale 0.7.1

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -187,3 +187,6 @@ pgvectorscale:
   0.7.0:
     pg-min: 13
     pg-max: 17
+  0.7.1:
+    pg-min: 13
+    pg-max: 17


### PR DESCRIPTION
We released [pgvectorscale 0.7.1](https://github.com/timescale/pgvectorscale/releases/tag/0.7.1) yesterday.