### PR TITLE
Update PostgreSQL versions to 17.9 and others

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -27,11 +27,11 @@ default-arch: both
 ## Please notice that pg 12 is EOL now and has no more updates, which is why it was removed:
 ## from https://www.postgresql.org/about/news/postgresql-174-168-1512-1417-and-1320-released-3018/
 postgres_versions:
-  17: 17.4
-  16: 16.8
-  15: 15.12
-  14: 14.17
-  13: 13.20
+  17: 17.5
+  16: 16.9
+  15: 15.13
+  14: 14.18
+  13: 13.21
 
 timescaledb:
   2.1.0:


### PR DESCRIPTION
Related with https://linear.app/timescale/issue/ORC-31/add-new-issue-to-update-versions-after-recent-release

This pull request updates the PostgreSQL versions in the `build_scripts/versions.yaml` file to reflect the latest patch releases. These updates ensure compatibility with the most recent security and bug fixes.

Version updates:

* Updated PostgreSQL versions:
  - `17` from `17.4` to `17.5`
  - `16` from `16.8` to `16.9`
  - `15` from `15.12` to `15.13`
  - `14` from `14.17` to `14.18`
  - `13` from `13.20` to `13.21` (`[build_scripts/versions.yamlL30-R34](diffhunk://#diff-c0b890f2279e6133d9571ea714e31f3fd24de4a888e0aaf595bd976f51aca419L30-R34)`)