### PR TITLE
add timescaledb 2.20.1

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -155,6 +155,9 @@ timescaledb:
   2.20.0:
     pg-min: 15
     pg-max: 17
+  2.20.1:
+    pg-min: 15
+    pg-max: 17
 
 toolkit:
   1.18.0:


### PR DESCRIPTION
### What does this do?
This PR adds the new release [2.20.1](https://github.com/timescale/timescaledb/releases/tag/2.20.1) to the public docker image.

### Resources
- [Releases Calendar](https://docs.google.com/spreadsheets/d/1MgRDRPq_BXrFzInVfcjmce6Qlpawoyc3XNakfwJpe6s/edit?pli=1&gid=0#gid=0)
- [Slab doc with instructions](https://timescale.slab.com/posts/deploying-a-new-timescale-db-extension-version-odw7b3br).
- [Slack thread](https://iobeam.slack.com/archives/C08EEJXQDLK/p1748353008934059)
- Example of [previous PR](https://github.com/timescale/timescaledb-docker-ha/pull/548) in this repo.