### PR TITLE
add timescaledb 2.20.2

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -158,6 +158,10 @@ timescaledb:
   2.20.1:
     pg-min: 15
     pg-max: 17
+  2.20.2:
+    pg-min: 15
+    pg-max: 17
+
 
 toolkit:
   1.18.0:


### PR DESCRIPTION
Emergency release of tsdb [v2.20.2](https://github.com/timescale/timescaledb/releases/tag/2.20.2).