### PR TITLE
Fix a logical condition when build pgai

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -323,7 +323,7 @@ RUN if [ -n "${PGAI_VERSION}" ]; then \
         git clone --branch "${PGAI_VERSION}" https://github.com/timescale/pgai.git /build/pgai; \
         cd /build/pgai; \
         for pg in ${PG_VERSIONS}; do \
-            [[ "$pg" -lt 16 && "$pg" -gt 17 ]] && continue; \
+            [[ "$pg" -lt 16 || "$pg" -gt 17 ]] && continue; \
             PG_BIN=$(/usr/lib/postgresql/${pg}/bin/pg_config --bindir) PG_MAJOR=${pg} ./projects/extension/build.py install all; \
         done; \
     fi


### PR DESCRIPTION
A bug here caused pgai to be build on earlier versions.
Since it is incompatible with p15 and earlier, it caused the migrations running on those services to fail.