### PR TITLE
Update PostgreSQL versions to latest patch releases

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -28,11 +28,11 @@ default-arch: both
 ## from https://www.postgresql.org/about/news/postgresql-174-168-1512-1417-and-1320-released-3018/
 postgres_versions:
   18: 18~beta1
-  17: 17.5
-  16: 16.9
-  15: 15.13
-  14: 14.18
-  13: 13.21
+  17: 17.6
+  16: 16.10
+  15: 15.14
+  14: 14.19
+  13: 13.22
 
 timescaledb:
   2.1.0:


### PR DESCRIPTION
- PostgreSQL 17.5 → 17.6
- PostgreSQL 16.9 → 16.10
- PostgreSQL 15.13 → 15.14
- PostgreSQL 14.18 → 14.19
- PostgreSQL 13.21 → 13.22

**Issues**

Closes https://linear.app/tigerdata/issue/PLA-48/add-latest-pg-minor-versions