### PR TITLE
add tsdb 2.21.4

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -177,6 +177,9 @@ timescaledb:
   2.21.3:
     pg-min: 15
     pg-max: 17
+  2.21.4:
+    pg-min: 15
+    pg-max: 17
   # TODO/NOTE: 2.22.0 is unstable and has some issues on cloud. Skip that version. Remove this comment
   # and enable 2.22.1 once it is available.
   # 2.22.1:


### PR DESCRIPTION
This commit adds tsdb 2.21.4.

----
This pull request updates the `build_scripts/versions.yaml` file to add support for TimescaleDB version 2.21.4, specifying its compatibility with PostgreSQL versions 15 through 17.

Dependency version update:

* Added TimescaleDB version `2.21.4` to the list of supported versions, with `pg-min` set to 15 and `pg-max` set to 17.