### PR TITLE
Add initialization of default PostgreSQL clusters for each version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -200,6 +200,7 @@ RUN packages=""; \
 # create the default clusters for each version on /usr/share/postgresql/$version/initdb_data
 RUN \
     mkdir -p /usr/share/postgresql/ && \
+    chown postgres:postgres /usr/share/postgresql/ && \
     install --directory /usr/share/postgresql/ --group postgres --mode 1775; \
     for pg in ${PG_VERSIONS}; do \
         su postgres -c "/usr/lib/postgresql/${pg}/bin/initdb \


### PR DESCRIPTION
----
This pull request updates the PostgreSQL Docker setup to automatically create default clusters for each supported version during image build. This change improves the initialization process and ensures that each PostgreSQL version has a pre-initialized data directory.

PostgreSQL initialization improvements:

* The Dockerfile now creates default clusters for each PostgreSQL version by running `initdb` for each version, setting up the initial data directory at `/usr/share/postgresql/$version/initdb_data` with appropriate authentication and data checksums.