### PR TITLE
fix: chown timescaledb.control to postgres so hot-forge can hot-patch it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -405,6 +405,17 @@ RUN OSS_ONLY="${OSS_ONLY}" \
         TIMESCALEDB_VERSIONS="${TIMESCALEDB_VERSIONS}" \
         /build/scripts/install_extensions timescaledb
 
+# The extension directories use a sticky bit (1775), which prevents the postgres user from
+# removing or renaming files owned by root — even when the directory itself is group-writable.
+# hot-forge replaces files by first removing them and then creating a symlink; for that to
+# work the file must be owned by postgres. The timescaledb loader package installs
+# timescaledb.control as root-owned, so we transfer ownership here. This allows hot-forge
+# to update default_version by replacing the file with a symlink to its live directory.
+RUN for pg in ${PG_VERSIONS}; do \
+        find "$(/usr/lib/postgresql/${pg}/bin/pg_config --sharedir)/extension" \
+            -name 'timescaledb*.control' -exec chown postgres:postgres {} \;; \
+    done
+
 USER postgres
 
 # install all rust packages in the same step to allow it to optimize for cargo-pgx installs


### PR DESCRIPTION
## Summary

- The extension directories are set up with sticky bit (`1775`, group=`postgres`), which prevents the postgres user from removing files owned by root even though the directory is group-writable
- hot-forge replaces files by first calling `remove_file` then creating a symlink; for `.so` files this works because they are new version-named files, but `timescaledb.control` is a fixed-name file installed as `root:root` by the loader apt package
- After the hot-forge bundle install, `default_version` in `pg_available_extensions` would stay at the image-baked version instead of reflecting the hot-patched version
- This adds a `chown postgres` step after installing the timescaledb packages, so hot-forge can remove the file and replace it with a symlink to its live directory

## Test plan

- [ ] Build a new image and verify `timescaledb.control` is postgres-owned: `stat /usr/share/postgresql/18/extension/timescaledb.control`
- [ ] Install a hot-forge bundle with a newer timescaledb version and verify `SELECT default_version FROM pg_available_extensions WHERE name = 'timescaledb'` returns the hot-patched version

Related PR https://github.com/timescale/hot-forge/pull/424