### PR TITLE
Remove ip4r package from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -181,7 +181,6 @@ RUN packages=""; \
             postgresql-${pg}-pgpcre postgresql-${pg}-pgpcre-dbgsym \
             postgresql-${pg}-wal2json postgresql-${pg}-wal2json-dbgsym \
             postgresql-${pg}-pgq3 postgresql-${pg}-pgq3-dbgsym \
-            postgresql-${pg}-ip4r postgresql-${pg}-ip4r-dbgsym \
             postgresql-${pg}-pgtap \
             postgresql-${pg}-semver postgresql-${pg}-semver-dbgsym \
             postgresql-${pg}-hypopg postgresql-${pg}-hypopg-dbgsym \

--- a/build_scripts/shared_versions.sh
+++ b/build_scripts/shared_versions.sh
@@ -7,7 +7,6 @@ PG_WANTED_EXTENSIONS=(
     h3_postgis
     hll
     hypopg
-    ip4r
     orafce
     pg-qualstats
     pg-stat-kcache


### PR DESCRIPTION
Removed postgresql-${pg}-ip4r and its debug symbol package from the Dockerfile due to security vulnerabilities