### PR TITLE
chore: include toolkit latest release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ RUN sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/cr
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.85.0
+    RUST_VERSION=1.90.0
 
 RUN dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \

--- a/Dockerfile
+++ b/Dockerfile
@@ -307,14 +307,6 @@ RUN for file in $(find /usr/share/postgresql -name 'postgresql.conf.sample'); do
         && echo "listen_addresses = '*'" >> $file; \
     done
 
-# pg_textsearch requires shared_preload_libraries (pg17+ only)
-RUN for file in $(find /usr/share/postgresql -name 'postgresql.conf.sample'); do \
-        pgver="$(basename "$(dirname "$file")")"; \
-        if [ "$pgver" -ge 17 ] 2>/dev/null; then \
-            sed -r -i "s/(shared_preload_libraries\s*=\s*'[^']*)/\1,pg_textsearch/" "$file"; \
-        fi; \
-    done
-
 RUN chown -R postgres:postgres /usr/local/cargo
 
 # required to install dbgsym packages
@@ -424,6 +416,17 @@ RUN PG_TEXTSEARCH_VERSION="${PG_TEXTSEARCH_VERSION}" \
     /build/scripts/install_extensions pg_textsearch
 
 USER root
+
+# pg_textsearch requires shared_preload_libraries (pg17+ only). This must run
+# AFTER pg_textsearch is installed: cargo-pgrx >= 0.18 runs initdb during
+# `cargo pgrx init` while building the toolkit, and a cluster that preloads a
+# not-yet-installed library fails to bootstrap (toolkit-1.23.0 build for pg17/18).
+RUN for file in $(find /usr/share/postgresql -name 'postgresql.conf.sample'); do \
+        pgver="$(basename "$(dirname "$file")")"; \
+        if [ "$pgver" -ge 17 ] 2>/dev/null; then \
+            sed -r -i "s/(shared_preload_libraries\s*=\s*'[^']*)/\1,pg_textsearch/" "$file"; \
+        fi; \
+    done
 
 # All the tools that were built in the previous steps have their ownership set to postgres
 # to allow mutability. To allow one to build this image with the default privileges (owned by root)

--- a/build_scripts/shared.sh
+++ b/build_scripts/shared.sh
@@ -180,8 +180,15 @@ cargo_pgrx_cmd() {
 }
 
 cargo_pgrx_init() {
-	local pgrx_version="$1" pg_ver="$2" pg_versions pgrx_cmd
+	local pgrx_version="$1" pg_ver="$2" pg_versions pgrx_cmd pg
 	pgrx_cmd="$(cargo_pgrx_cmd "$pgrx_version")"
+
+	# Matches only the old cargo-pgx 0.0-0.5 series, which predates pg15 support.
+	# Must be a quoted variable so the backslashes survive as regex (an inline
+	# pattern has them stripped, turning "\." into any-char) and so the minor
+	# component is bounded by a dot/end-of-string -- otherwise 0.18 etc. is
+	# mistaken for the 0.1 series.
+	local old_pgx_series='^0\.[0-5]([.]|$)'
 
 	if [ "$pgrx_cmd" = pgx ]; then
 		if ! require_cargo_pgx_version "$pgrx_version"; then
@@ -195,7 +202,7 @@ cargo_pgrx_init() {
 		fi
 	fi
 
-	if [[ -z "$pg_ver" || "$pg" -ge 15 && "$pgrx_version" =~ ^0\.[0-5]\.* ]]; then
+	if [[ -z "$pg_ver" || "$pg" -ge 15 && "$pgrx_version" =~ $old_pgx_series ]]; then
 		pg_versions="$(available_pg_versions)"
 	else
 		pg_versions="$pg_ver"
@@ -203,7 +210,7 @@ cargo_pgrx_init() {
 	args=()
 	for pg in $pg_versions; do
 		# pgrx only got the pg15 feature in 0.6.0
-		[[ "$pgrx_version" =~ ^0\.[0-5]\.* && $pg -ge 15 ]] && continue
+		[[ "$pgrx_version" =~ $old_pgx_series && $pg -ge 15 ]] && continue
 
 		args+=("--pg${pg}" "/usr/lib/postgresql/${pg}/bin/pg_config")
 	done

--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -168,6 +168,10 @@ toolkit:
     cargo-pgrx: 0.16.1
     pg-min: 15
     pg-max: 18
+  1.23.0:
+    cargo-pgrx: 0.18.0
+    pg-min: 15
+    pg-max: 18
 
 pgvectorscale:
   0.2.0:


### PR DESCRIPTION
- Bumps Rust to 1.90.0 and cargo-pgrx to 0.18.0 to include the latest toolkit release.
- Fixed a broken version-detection regex by quoting it, stopping cargo-pgrx 0.18.0 from being misidentified as legacy, which broke system Postgres provisioning.
- Deferred adding pg_textsearch to shared_preload_libraries until after it is installed, preventing initdb from failing on pg17/18 due to a missing library.