### PR TITLE
fix: drop uv build cache from image to cut ~1.3G

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -538,6 +538,7 @@ RUN set -ex; \
             /usr/share/locale/?? \
             /usr/share/locale/??_?? \
             /home/postgres/.pgx \
+            /home/postgres/.cache \
             /build/ \
             /usr/local/rustup \
             /usr/local/cargo \


### PR DESCRIPTION
The HA image ships a ~1.3G uv build cache (`/home/postgres/.cache`) that nothing reads at runtime. pgai's `build.py install` runs `uv` as `USER postgres`, populating `~/.cache/uv`; the `trimmed` stage's cleanup deletes `.pgx`, `/build`, the rust toolchains, docs and man pages but never `.cache`, so the cache rides along in the final `COPY --from=trimmed / /` layer. On `pg16-ts2.23` that's ~1.3G of ~5.4G uncompressed, the biggest single avoidable chunk after pgai itself.

Add `/home/postgres/.cache` to that existing `rm -rf`.

Safe to drop: the cache is consulted only by `uv` during installs, which happen at build time, never at container runtime. Postgres loads the already-installed extension files from `/usr/local/lib/pgai/<ver>`, and `CREATE EXTENSION ai` / `ALTER EXTENSION ai UPDATE` resolve against those per-version dirs, not the cache. The installed files are independent copies (distinct inodes from the cache; the installed pyarrow is even hardlinked across the pgai version dirs that share it), so removing the cache deletes nothing functional. Worst case is a cold cache if someone derives `FROM` this image and runs new `uv` installs.
