### PR TITLE
Cleanup the runner on check steps too

### DIFF
--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -176,6 +176,17 @@ jobs:
         docker_tag_postfix: ["", "-all", "-oss", "-all-oss" ]
 
     steps:
+      # Free up disk space on the runner. The check pulls both the amd64 and
+      # arm64 variants of the image, and the pg*-all images in particular are
+      # large enough that a stock runner's ~14GB free on / overflows otherwise.
+      - name: remove unneeded runner software
+        run: |
+          df -h
+          sudo rm -fr /usr/share/dotnet /usr/local/lib/android /opt/microsoft \
+                      /opt/hostedtoolcache /usr/local/.ghcup /usr/local/share/boost || true
+          sudo docker image prune --all --force || true
+          df -h
+
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/Makefile
+++ b/Makefile
@@ -347,6 +347,9 @@ check: # check images to see if they have all the requested content
 		docker exec -e GITHUB_STEP_SUMMARY="/tmp/step_summary-$$key" -e CI="$(CI)" "$$check_name" /cicd/install_checks -v || { docker logs -n100 "$$check_name"; exit 1; }
 		docker exec "$$check_name" cat "/tmp/step_summary-$$key" >> "$(GITHUB_STEP_SUMMARY)" 2>&1
 		docker rm --force "$$check_name" >&/dev/null || true
+		# Drop the image before pulling the next arch; the pg*-all images are
+		# large enough that holding both amd64 and arm64 at once fills the disk.
+		docker rmi --force "$(DOCKER_RELEASE_URL)" >&/dev/null || true
 	done
 
 .PHONY: check-sha


### PR DESCRIPTION
We were cleaning up on build steps, but not check steps, and it's close enough to cause intermittent job failures.