### PR TITLE
Add tsdb 2.27.2

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -143,7 +143,7 @@ timescaledb:
   2.27.0:
     pg-min: 15
     pg-max: 18
-  2.27.1:
+  2.27.2:
     pg-min: 15
     pg-max: 18
 


### PR DESCRIPTION
There is only one DB running 2.27.1 and there's no need to keep 2.27.1 in the image. That DB will be addressed by a targeted hot-forge to avoid that it stays without extension files