### PR TITLE
feat: set synchronized_standby_slots on role change for logical slot failover

### DIFF
--- a/scripts/on_role_change.sh
+++ b/scripts/on_role_change.sh
@@ -3,3 +3,32 @@
 cat <<EOT
 $(date) - $0 - I was called with the following parameters: $@
 EOT
+
+# Keep synchronized_standby_slots correct for logical-replication-slot failover:
+# only the primary should advertise the physical standby slots; standbys clear it.
+# Patroni appends "<action> <role> <scope>" to the configured command, so the new
+# role is always the second-to-last argument regardless of any leading args.
+set -euo pipefail
+
+role="${@: -2:1}"
+
+case "$role" in
+  master|primary)
+    # List the physical slots currently streamed by connected standbys. "active"
+    # guarantees the slot exists (naming a missing slot stalls logical decoding)
+    # and needs no member-naming convention, so this stays generic to the image.
+    # ponytail: includes ANY active physical streamer; if a separate read-replica
+    #           cluster streams from this primary and must be excluded, filter by
+    #           this cluster's Patroni members (patronictl list / REST /cluster).
+    slots="$(psql -qtAX -d postgres -c \
+      "SELECT coalesce(string_agg(slot_name, ','), '') FROM pg_replication_slots \
+        WHERE slot_type = 'physical' AND NOT temporary AND active")"
+    psql -qtAX -d postgres -c "ALTER SYSTEM SET synchronized_standby_slots = '${slots}'"
+    ;;
+  *)
+    # replica / standby_leader / demoted: a non-primary must not advertise slots.
+    psql -qtAX -d postgres -c "ALTER SYSTEM RESET synchronized_standby_slots"
+    ;;
+esac
+
+psql -qtAX -d postgres -c "SELECT pg_reload_conf()"

--- a/scripts/on_role_change.sh
+++ b/scripts/on_role_change.sh
@@ -10,7 +10,7 @@ EOT
 # role is always the second-to-last argument regardless of any leading args.
 set -euo pipefail
 
-role="${@: -2:1}"
+role="${*: -2:1}"
 
 case "$role" in
   master|primary)


### PR DESCRIPTION
## Why

Logical replication slots only survive a failover if the physical standbys have received the WAL before logical subscribers consume past it. Postgres gates this with `synchronized_standby_slots` — but it must be set **only on the primary**: it names physical standby slots, a primary has no slot for itself, and a stale value naming the new primary's own slot stalls logical decoding after promotion.

It's node-local and dynamic, so it can't come from the cluster-wide Patroni DCS (deployer/operator). The `on_role_change` callback is the right place.

## What

- **promote** → `ALTER SYSTEM SET synchronized_standby_slots` to the currently-active physical slots, then reload.
- **demote** (replica/standby_leader) → `ALTER SYSTEM RESET`, then reload.

`active` ensures the slot exists (a missing slot would stall decoding) and keeps the query generic — no member-naming convention baked into the image.

### Known limitation
Snapshots at promotion; standbys reconnecting later aren't re-added until the next role change. Safe — a short/empty list never stalls, only reduces protection briefly.

Fixes CON-1935