### PR TITLE
Add timescaledb 2.28.1

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -152,6 +152,9 @@ timescaledb:
   2.28.0:
     pg-min: 15
     pg-max: 18
+  2.28.1:
+    pg-min: 15
+    pg-max: 18
 
 
   # main is the tip of timescaledb


### PR DESCRIPTION
Adds the TimescaleDB 2.28.1 extension build (pg 15-18) to `versions.yaml` for the public and cloud images. Part of the 2.28.1 cloud release.