### PR TITLE
Add timescaledb 2.28.2

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -155,6 +155,9 @@ timescaledb:
   2.28.1:
     pg-min: 15
     pg-max: 18
+  2.28.2:
+    pg-min: 15
+    pg-max: 18
 
 
   # main is the tip of timescaledb


### PR DESCRIPTION
Adds the TimescaleDB 2.28.2 extension build (pg 15-18) to `versions.yaml` for the public and cloud images. Part of the 2.28.2 cloud release.

Release: https://github.com/timescale/timescaledb/releases/tag/2.28.2