### PR TITLE
Add timescaledb 2.29.1

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -162,6 +162,9 @@ timescaledb:
   2.29.0:
     pg-min: 16
     pg-max: 18
+  2.29.1:
+    pg-min: 16
+    pg-max: 18
 #   # main is the tip of timescaledb
 #   main:
 #    pg-min: 16


### PR DESCRIPTION
Adds TimescaleDB 2.29.1 to the image builds.

Release notes: https://github.com/timescale/timescaledb/releases/tag/2.29.1