### PR TITLE
Shrink the builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,12 @@
 ## tools we use will be the same across the board, as most of our tools our
 ## installed using external repositories.
 ARG DOCKER_FROM=ubuntu:22.04
-FROM ${DOCKER_FROM} AS builder
+ARG RUST_VERSION=1.96.0
+ARG BUILD_PACKAGES="binutils cmake devscripts equivs gcc git gpg gpg-agent libc-dev libc6-dev libkrb5-dev libperl-dev libssl-dev lsb-release make patchutils python2-dev python3-dev wget libsodium-dev"
+
+## The build-stage does all the work. The published `builder` target below
+## copies its filesystem into a single layer.
+FROM ${DOCKER_FROM} AS build-stage
 
 SHELL ["/bin/bash", "-exu", "-o", "pipefail", "-c"]
 
@@ -112,10 +117,11 @@ RUN pkg="pgbouncer_exporter-${PGBOUNCER_EXPORTER_VERSION}.linux-$(dpkg --print-a
 RUN sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf
 
 # The next 2 instructions (ENV + RUN) are directly copied from https://github.com/rust-lang/docker-rust/blob/master/stable/bullseye/Dockerfile
+ARG RUST_VERSION
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.96.0
+    RUST_VERSION=${RUST_VERSION}
 
 RUN dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
@@ -147,7 +153,8 @@ RUN apt-get install -y python3 python3-pip
 
 # We install some build dependencies and mark the installed packages as auto-installed,
 # this will cause the cleanup to get rid of all of these packages
-ENV BUILD_PACKAGES="binutils cmake devscripts equivs gcc git gpg gpg-agent libc-dev libc6-dev libkrb5-dev libperl-dev libssl-dev lsb-release make patchutils python2-dev python3-dev wget libsodium-dev"
+ARG BUILD_PACKAGES
+ENV BUILD_PACKAGES="${BUILD_PACKAGES}"
 RUN apt-get install -y ${BUILD_PACKAGES}
 RUN apt-mark auto ${BUILD_PACKAGES}
 
@@ -425,7 +432,10 @@ RUN if [ "${ALLOW_ADDING_EXTENSIONS}" != "true" ]; then \
         done; \
     fi
 
-RUN apt-get clean
+# Cargo recreates the unpacked crate sources from registry/cache when it
+# needs them.
+RUN apt-get clean; \
+    rm -rf /usr/local/cargo/registry/src
 
 ARG PG_MAJOR
 ENTRYPOINT ["/docker-entrypoint.sh"]
@@ -520,7 +530,42 @@ USER postgres
 COPY --chown=postgres:postgres cicd /cicd/
 RUN /cicd/install_checks -v
 
-FROM builder AS trimmed
+## The published builder image is one layer. A chown or chmod on a file from
+## an earlier layer copies that file into a new layer; one layer avoids the
+## duplicates. The image config below must match what build-stage sets.
+FROM scratch AS builder
+COPY --from=build-stage / /
+
+SHELL ["/bin/bash", "-exu", "-o", "pipefail", "-c"]
+
+ARG PG_MAJOR
+ARG RUST_VERSION
+ARG BUILD_PACKAGES
+ENV DEBIAN_FRONTEND=noninteractive \
+    RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    RUST_VERSION=${RUST_VERSION} \
+    BUILD_PACKAGES="${BUILD_PACKAGES}" \
+    MAKEFLAGS=-j4 \
+    PGROOT=/home/postgres \
+    PGDATA=/home/postgres/pgdata/data \
+    PGLOG=/home/postgres/pg_log \
+    PGSOCKET=/home/postgres/pgdata \
+    BACKUPROOT=/home/postgres/pgdata/backup \
+    PGBACKREST_CONFIG=/home/postgres/pgdata/backup/pgbackrest.conf \
+    PGBACKREST_STANZA=poddb \
+    PATH=/usr/lib/postgresql/${PG_MAJOR}/bin:/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8 \
+    PAGER=""
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["postgres"]
+WORKDIR /home/postgres
+EXPOSE 5432 8008 8081
+USER postgres
+
+FROM build-stage AS trimmed
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,7 @@
 ## tools we use will be the same across the board, as most of our tools our
 ## installed using external repositories.
 ARG DOCKER_FROM=ubuntu:22.04
-ARG RUST_VERSION=1.96.0
-ARG BUILD_PACKAGES="binutils cmake devscripts equivs gcc git gpg gpg-agent libc-dev libc6-dev libkrb5-dev libperl-dev libssl-dev lsb-release make patchutils python2-dev python3-dev wget libsodium-dev"
-
-## The build-stage does all the work. The published `builder` target below
-## copies its filesystem into a single layer.
-FROM ${DOCKER_FROM} AS build-stage
+FROM ${DOCKER_FROM} AS builder
 
 SHELL ["/bin/bash", "-exu", "-o", "pipefail", "-c"]
 
@@ -117,11 +112,10 @@ RUN pkg="pgbouncer_exporter-${PGBOUNCER_EXPORTER_VERSION}.linux-$(dpkg --print-a
 RUN sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf
 
 # The next 2 instructions (ENV + RUN) are directly copied from https://github.com/rust-lang/docker-rust/blob/master/stable/bullseye/Dockerfile
-ARG RUST_VERSION
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=${RUST_VERSION}
+    RUST_VERSION=1.96.0
 
 RUN dpkgArch="$(dpkg --print-architecture)"; \
     case "${dpkgArch##*-}" in \
@@ -138,6 +132,7 @@ RUN dpkgArch="$(dpkg --print-architecture)"; \
     ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
     rm rustup-init; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    chown -R postgres:postgres $CARGO_HOME; \
     rustup --version; \
     cargo --version; \
     rustc --version
@@ -153,8 +148,7 @@ RUN apt-get install -y python3 python3-pip
 
 # We install some build dependencies and mark the installed packages as auto-installed,
 # this will cause the cleanup to get rid of all of these packages
-ARG BUILD_PACKAGES
-ENV BUILD_PACKAGES="${BUILD_PACKAGES}"
+ENV BUILD_PACKAGES="binutils cmake devscripts equivs gcc git gpg gpg-agent libc-dev libc6-dev libkrb5-dev libperl-dev libssl-dev lsb-release make patchutils python2-dev python3-dev wget libsodium-dev"
 RUN apt-get install -y ${BUILD_PACKAGES}
 RUN apt-mark auto ${BUILD_PACKAGES}
 
@@ -314,12 +308,10 @@ RUN for file in $(find /usr/share/postgresql -name 'postgresql.conf.sample'); do
         && echo "listen_addresses = '*'" >> $file; \
     done
 
-RUN chown -R postgres:postgres /usr/local/cargo
-
-# required to install dbgsym packages
+# required to install dbgsym packages. Only the directories change: a chgrp
+# or chmod on a file from an earlier layer copies the whole file into this layer.
 RUN mkdir -p /usr/lib/debug; \
-    chgrp -R postgres /usr/lib/debug; \
-    chmod -R g+w /usr/lib/debug
+    find /usr/lib/debug -type d -exec chgrp postgres {} + -exec chmod g+w {} +
 
 USER postgres
 
@@ -432,10 +424,7 @@ RUN if [ "${ALLOW_ADDING_EXTENSIONS}" != "true" ]; then \
         done; \
     fi
 
-# Cargo recreates the unpacked crate sources from registry/cache when it
-# needs them.
-RUN apt-get clean; \
-    rm -rf /usr/local/cargo/registry/src
+RUN apt-get clean
 
 ARG PG_MAJOR
 ENTRYPOINT ["/docker-entrypoint.sh"]
@@ -530,42 +519,7 @@ USER postgres
 COPY --chown=postgres:postgres cicd /cicd/
 RUN /cicd/install_checks -v
 
-## The published builder image is one layer. A chown or chmod on a file from
-## an earlier layer copies that file into a new layer; one layer avoids the
-## duplicates. The image config below must match what build-stage sets.
-FROM scratch AS builder
-COPY --from=build-stage / /
-
-SHELL ["/bin/bash", "-exu", "-o", "pipefail", "-c"]
-
-ARG PG_MAJOR
-ARG RUST_VERSION
-ARG BUILD_PACKAGES
-ENV DEBIAN_FRONTEND=noninteractive \
-    RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    RUST_VERSION=${RUST_VERSION} \
-    BUILD_PACKAGES="${BUILD_PACKAGES}" \
-    MAKEFLAGS=-j4 \
-    PGROOT=/home/postgres \
-    PGDATA=/home/postgres/pgdata/data \
-    PGLOG=/home/postgres/pg_log \
-    PGSOCKET=/home/postgres/pgdata \
-    BACKUPROOT=/home/postgres/pgdata/backup \
-    PGBACKREST_CONFIG=/home/postgres/pgdata/backup/pgbackrest.conf \
-    PGBACKREST_STANZA=poddb \
-    PATH=/usr/lib/postgresql/${PG_MAJOR}/bin:/usr/local/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-    LC_ALL=C.UTF-8 \
-    LANG=C.UTF-8 \
-    PAGER=""
-
-ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD ["postgres"]
-WORKDIR /home/postgres
-EXPOSE 5432 8008 8081
-USER postgres
-
-FROM build-stage AS trimmed
+FROM builder AS trimmed
 
 USER root
 

--- a/build_scripts/install_extensions
+++ b/build_scripts/install_extensions
@@ -54,3 +54,10 @@ pg_textsearch | all)
     ;;
 
 esac
+
+# An install sets mode 755 on the .so files. Fix the mode in this image layer.
+# A chmod in a later layer copies every changed file into that layer. Only the
+# owner can chmod a file, so limit the find to files of the current user.
+if [ "$what" != versions ] && [ "$DRYRUN" != true ]; then
+    find /usr/lib/postgresql/*/lib -name '*.so' -perm /111 -user "$(id -un)" -exec chmod -x {} +
+fi

--- a/build_scripts/install_extensions
+++ b/build_scripts/install_extensions
@@ -35,6 +35,8 @@ timescaledb | all)
     for ver in $TIMESCALEDB_VERSIONS; do
         install_timescaledb "$ver"
     done
+    # the source tree and build directory are not needed after install
+    rm -rf /build/timescaledb
     ;;& # fallthrough to get rust as well if we're called with 'all'
 
 pgvectorscale | all)

--- a/build_scripts/shared_versions.sh
+++ b/build_scripts/shared_versions.sh
@@ -144,8 +144,9 @@ install_rust_extensions() {
             esac
         done
     done
-    # the source tree and cargo target directory are not needed after install
-    rm -rf /build/toolkit
+    # the source tree and cargo target directory are not needed after install.
+    # cargo recreates registry/src from registry/cache when it needs it.
+    rm -rf /build/toolkit /usr/local/cargo/registry/src
 }
 
 version_is_supported() {

--- a/build_scripts/shared_versions.sh
+++ b/build_scripts/shared_versions.sh
@@ -144,6 +144,8 @@ install_rust_extensions() {
             esac
         done
     done
+    # the source tree and cargo target directory are not needed after install
+    rm -rf /build/toolkit
 }
 
 version_is_supported() {


### PR DESCRIPTION
## Summary

The `pgNN-all-builder` image is 4.97 GB compressed. This PR cuts it to 3.39 GB (-32%) and keeps the layer structure. The files that downstream builds use do not change.

## Why the image is large

Image layers are copy-on-write. When a later `RUN` changes the mode or owner of a file from an earlier layer, Docker copies the whole file into the new layer. Three such steps hold 815 MiB of duplicate data, 18% of the image:

| Layer | Command | Size |
|---|---|---|
| 62 | `chmod -x /usr/lib/postgresql/*/lib/*.so` | 565 MiB |
| 43 | `chgrp -R postgres /usr/lib/debug` | 170 MiB |
| 42 | `chown -R postgres /usr/local/cargo` | 80 MiB |

A delete in a later layer has the same problem: the bytes stay in the lower layer.

## Changes

1. **Remove build trees after install, in the same step.** `/build/toolkit` (1.7 GB, mostly the cargo `target/` directory) and `/build/timescaledb` (0.2 GB) stay in the image today. The pgvectorscale and pg_textsearch installs already remove their trees. This PR does the same for toolkit and timescaledb, inside `install_extensions`.

2. **Remove `/usr/local/cargo/registry/src`** (0.95 GB) in the same step that builds the rust extensions. Cargo recreates these files from `registry/cache` when a build needs them.

3. **Fix the three copy-on-write steps at the source.**
   - `chown` of `/usr/local/cargo` moves into the `RUN` that installs rust.
   - `/usr/lib/debug` gets `chgrp` and `g+w` on the directories only. The dbgsym files stay in their own layer. Postgres can still add files to those directories.
   - `install_extensions` runs `chmod -x` on the `.so` files it installed, in the layer that created them. The final `chmod -x` in the Dockerfile then finds nothing to change. Coreutils skips files that already have the target mode, so a no-op chmod costs no layer space.

## Result

Measured on the images that the `publish_check` run for 3773a80 pushed ([run 33896369024](https://github.com/timescale/timescaledb-docker-ha/actions/runs/33896369024)). The run also passes the builder smoketest.

| Image (amd64) | Layers | Compressed |
|---|---|---|
| `pg18-all-builder-amd64` (master) | 68 | 4.97 GB |
| `pg18-cicheck-all-builder-amd64` (this PR) | 67 | 3.39 GB |
