### PR TITLE
Pin PG minors to the 2026-08-13 release set

### DIFF
--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -30,13 +30,11 @@ jobs:
         platform: [ amd64, arm64 ]
         include:
           - platform: amd64
-            runs_on: runs-on/fleet=linux-8cpu-x64/env=ue1
+            runs_on: ubuntu-22.04
           - platform: arm64
-            runs_on: runs-on/fleet=linux-8cpu/env=ue1
+            runs_on: cloud-image-runner-arm64
 
     steps:
-      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
-
       # Free up disk space on the runner. The pg18-all builds in particular need
       # a lot of space due to 4 PG versions worth of extensions and debug symbols.
       - name: remove unneeded runner software
@@ -84,11 +82,9 @@ jobs:
   publish-combined-manifest:
     name: Publish branch manifest
     needs: [ "build-branch" ]
-    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
-
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -30,11 +30,13 @@ jobs:
         platform: [ amd64, arm64 ]
         include:
           - platform: amd64
-            runs_on: ubuntu-22.04
+            runs_on: runs-on/fleet=linux-8cpu-x64/env=ue1
           - platform: arm64
-            runs_on: cloud-image-runner-arm64
+            runs_on: runs-on/fleet=linux-8cpu/env=ue1
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       # Free up disk space on the runner. The pg18-all builds in particular need
       # a lot of space due to 4 PG versions worth of extensions and debug symbols.
       - name: remove unneeded runner software
@@ -82,9 +84,11 @@ jobs:
   publish-combined-manifest:
     name: Publish branch manifest
     needs: [ "build-branch" ]
-    runs-on: ubuntu-latest
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/.github/workflows/publish_check.yaml
+++ b/.github/workflows/publish_check.yaml
@@ -21,9 +21,11 @@ jobs:
   # disk space, build, and manifest issues before they hit the publish workflow.
   publish-check:
     name: Dry run pg18-all amd64
-    runs-on: ubuntu-22.04
+    runs-on: runs-on/fleet=linux-8cpu-x64/env=ue1
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: remove unneeded runner software
         run: |
           df -h

--- a/.github/workflows/publish_check.yaml
+++ b/.github/workflows/publish_check.yaml
@@ -21,11 +21,9 @@ jobs:
   # disk space, build, and manifest issues before they hit the publish workflow.
   publish-check:
     name: Dry run pg18-all amd64
-    runs-on: runs-on/fleet=linux-8cpu-x64/env=ue1
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
-
       - name: remove unneeded runner software
         run: |
           df -h

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -39,13 +39,15 @@ jobs:
           - all_versions: "true"
             all: "-all"
           - platform: amd64
-            runs_on: ubuntu-22.04
+            runs_on: runs-on/fleet=linux-8cpu-x64/env=ue1
           - platform: arm64
-            runs_on: cloud-image-runner-arm64
+            runs_on: runs-on/fleet=linux-8cpu/env=ue1
 
     runs-on: "${{ matrix.runs_on }}"
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       # Free up disk space on the runner. The pg18-all builds in particular need
       # a lot of space due to 4 PG versions worth of extensions and debug symbols.
       - name: remove unneeded runner software
@@ -107,7 +109,7 @@ jobs:
   publish-combined-manifests:
     name: Publish manifest pg${{ matrix.pg_major }}${{ matrix.docker_tag_postfix }}
     needs: [ "publish" ]
-    runs-on: ubuntu-latest
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     strategy:
       fail-fast: false
 
@@ -129,6 +131,8 @@ jobs:
             all_versions: "true"
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Download arm64 outputs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -168,7 +172,7 @@ jobs:
   check:
     name: Check image pg${{ matrix.pg_major }}${{ matrix.docker_tag_postfix }}
     needs: [ "publish", "publish-combined-manifests" ]
-    runs-on: ubuntu-latest
+    runs-on: runs-on/fleet=linux-4cpu-x64/env=ue1
     strategy:
       fail-fast: false
       matrix:
@@ -176,6 +180,8 @@ jobs:
         docker_tag_postfix: ["", "-all", "-oss", "-all-oss" ]
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       # Free up disk space on the runner. The check pulls both the amd64 and
       # arm64 variants of the image, and the pg*-all images in particular are
       # large enough that a stock runner's ~14GB free on / overflows otherwise.
@@ -210,9 +216,11 @@ jobs:
     name: Dispatch HA image published event
     needs: [ "check" ]
     if: ${{ github.event_name == 'push' }}
-    runs-on: ubuntu-latest
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Dispatch event to Publish cloud images workflow
         run: |
             curl -H "Accept: application/vnd.github.everest-preview+json" \

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -39,15 +39,13 @@ jobs:
           - all_versions: "true"
             all: "-all"
           - platform: amd64
-            runs_on: runs-on/fleet=linux-8cpu-x64/env=ue1
+            runs_on: ubuntu-22.04
           - platform: arm64
-            runs_on: runs-on/fleet=linux-8cpu/env=ue1
+            runs_on: cloud-image-runner-arm64
 
     runs-on: "${{ matrix.runs_on }}"
 
     steps:
-      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
-
       # Free up disk space on the runner. The pg18-all builds in particular need
       # a lot of space due to 4 PG versions worth of extensions and debug symbols.
       - name: remove unneeded runner software
@@ -109,7 +107,7 @@ jobs:
   publish-combined-manifests:
     name: Publish manifest pg${{ matrix.pg_major }}${{ matrix.docker_tag_postfix }}
     needs: [ "publish" ]
-    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
 
@@ -131,8 +129,6 @@ jobs:
             all_versions: "true"
 
     steps:
-      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
-
       - name: Download arm64 outputs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -172,7 +168,7 @@ jobs:
   check:
     name: Check image pg${{ matrix.pg_major }}${{ matrix.docker_tag_postfix }}
     needs: [ "publish", "publish-combined-manifests" ]
-    runs-on: runs-on/fleet=linux-4cpu-x64/env=ue1
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -180,8 +176,6 @@ jobs:
         docker_tag_postfix: ["", "-all", "-oss", "-all-oss" ]
 
     steps:
-      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
-
       # Free up disk space on the runner. The check pulls both the amd64 and
       # arm64 variants of the image, and the pg*-all images in particular are
       # large enough that a stock runner's ~14GB free on / overflows otherwise.
@@ -216,11 +210,9 @@ jobs:
     name: Dispatch HA image published event
     needs: [ "check" ]
     if: ${{ github.event_name == 'push' }}
-    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
-
       - name: Dispatch event to Publish cloud images workflow
         run: |
             curl -H "Accept: application/vnd.github.everest-preview+json" \

--- a/.github/workflows/test-shell-scripts.yaml
+++ b/.github/workflows/test-shell-scripts.yaml
@@ -5,9 +5,11 @@ on:
 jobs:
   tests:
     name: Test System Services
-    runs-on: ubuntu-latest
+    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
     timeout-minutes: 2
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/test-shell-scripts.yaml
+++ b/.github/workflows/test-shell-scripts.yaml
@@ -5,11 +5,9 @@ on:
 jobs:
   tests:
     name: Test System Services
-    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
-
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,12 @@ $(VERSION_INFO): builder
 endif
 VERSION_IMAGE := $(DOCKER_PUBLISH_URL):$(VERSION_TAG)
 
+# Docker 29 on Ubuntu 26.04 gives "docker exec" processes the AppArmor label
+# docker-default//&unconfined. The docker-default profile then denies signals
+# between processes in the container. PostgreSQL 18 AIO workers need SIGURG,
+# so connections hang. Run the containers that start PostgreSQL unconfined.
+DOCKER_APPARMOR_ARG=--security-opt apparmor=unconfined
+
 # The purpose of publishing the images under many tags, is to provide
 # some choice to the user as to their appetite for volatility.
 #
@@ -128,7 +134,7 @@ VERSION_IMAGE := $(DOCKER_PUBLISH_URL):$(VERSION_TAG)
 
 $(VERSION_INFO):
 	docker rm --force builder_inspector >&/dev/null || true
-	docker run --rm -d --name builder_inspector -e PGDATA=/tmp/pgdata --user=postgres "$(VERSION_IMAGE)" sleep 300
+	docker run --rm -d $(DOCKER_APPARMOR_ARG) --name builder_inspector -e PGDATA=/tmp/pgdata --user=postgres "$(VERSION_IMAGE)" sleep 300
 	docker cp ./cicd "builder_inspector:/cicd/"
 	docker exec builder_inspector /cicd/smoketest.sh || (docker logs -n100 builder_inspector && exit 1)
 	mkdir -p /tmp/outputs
@@ -331,6 +337,7 @@ check: # check images to see if they have all the requested content
 		docker rm --force "$$check_name" >&/dev/null || true
 		docker run \
 			--platform linux/"$$arch" \
+			$(DOCKER_APPARMOR_ARG) \
 			--pull always \
 			-d \
 			--name "$$check_name" \
@@ -362,6 +369,7 @@ check-sha: # check a specific git commit-based image
 	docker rm --force "$$check_name" >&/dev/null || true
 	docker run \
 		--platform linux/"$$arch" \
+		$(DOCKER_APPARMOR_ARG) \
 		-d \
 		--name "$$check_name" \
 		-e PGDATA=/tmp/pgdata \

--- a/build_scripts/shared_install.sh
+++ b/build_scripts/shared_install.sh
@@ -65,12 +65,33 @@ install_timescaledb_for_pg_version() {
     local package_suffix
     local loader_package
     local main_package
+    local candidate
+    local -a suffixes=()
 
     os_suffix="$(get_package_suffix)"
 
-    # Try the current PG minor suffix first; fall back to the previous minor if
-    # packages haven't been published for the new PG minor yet.
-    for suffix in "${pg_full_suffix}" "$((pg_full_suffix - 1))"; do
+    # Try the pinned PG minor first, then walk back through preceding minors.
+    # Two reasons a single step back is not enough: packages for a new PG minor
+    # are published some time after the minor itself, and an older timescaledb
+    # version is only ever built against the minor that was current when it was
+    # released, so it can sit several minors behind the pin.
+    #
+    # Minors upstream never shipped are stepped over, since they would be tried
+    # and always miss. PostgreSQL 18.5 "was not shipped due to a regression",
+    # which makes 18.4 the real predecessor of 18.6:
+    # https://www.postgresql.org/about/news/postgresql-186-1711-1615-1519-1424-and-19-beta-3-released-3365/
+    local -r skipped_minors=" 1805 "
+    local -r fallback_depth=3
+
+    candidate="${pg_full_suffix}"
+    while [ "${#suffixes[@]}" -lt "${fallback_depth}" ]; do
+        if [[ "${skipped_minors}" != *" ${candidate} "* ]]; then
+            suffixes+=("${candidate}")
+        fi
+        candidate=$((candidate - 1))
+    done
+
+    for suffix in "${suffixes[@]}"; do
         package_suffix="${os_suffix}-${suffix}"
         loader_package=$(construct_loader_package_name "${pg_version}" "${ts_version}" "${package_suffix}")
         main_package=$(construct_package_name "${pg_version}" "${ts_version}" "${package_suffix}")

--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -26,11 +26,14 @@ default-arch: both
 ## from https://www.postgresql.org/about/news/postgresql-186-1711-1615-1519-1424-and-19-beta-3-released-3365/
 ## 18.5 is absent on purpose: it "was not shipped due to a regression", so
 ## upstream went from 18.4 straight to 18.6.
+## 15 deliberately stays on the May set: PG15 is being deprecated, and
+## timescaledb already dropped support for it in 2.29.0, so a minor bump
+## this close to removal buys nothing.
 postgres_versions:
   18: 18.6
   17: 17.11
   16: 16.15
-  15: 15.19
+  15: 15.18
 timescaledb:
   2.13.0:
     pg-max: 16

--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -23,12 +23,14 @@ default-pg-max: 18
 default-cargo-pgx: 0.6.1
 default-arch: both
 ## This section contains the specific pg versions that will be installed.
-## from https://www.postgresql.org/about/news/postgresql-184-1710-1614-1518-and-1423-released-3297/
+## from https://www.postgresql.org/about/news/postgresql-186-1711-1615-1519-1424-and-19-beta-3-released-3365/
+## 18.5 is absent on purpose: it "was not shipped due to a regression", so
+## upstream went from 18.4 straight to 18.6.
 postgres_versions:
-  18: 18.4
-  17: 17.10
-  16: 16.14
-  15: 15.18
+  18: 18.6
+  17: 17.11
+  16: 16.15
+  15: 15.19
 timescaledb:
   2.13.0:
     pg-max: 16

--- a/cicd/smoketest.sh
+++ b/cicd/smoketest.sh
@@ -23,9 +23,22 @@ echo "shared_preload_libraries='${SHARED_PRELOAD_LIBRARIES}'" >>"${PGDATA}/postg
 
 pg_ctl start
 
-while ! pg_isready; do
+# Bounded on purpose: an unbounded wait turns "the server never came up" into a
+# silent hang until the surrounding container is reaped, which then surfaces as
+# an unrelated docker error instead of the actual failure.
+ready=false
+for _ in $(seq 1 150); do
+	if pg_isready -q; then ready=true; break; fi
 	sleep 0.2
 done
+
+if [ "${ready}" != true ]; then
+	echo "smoketest: server did not accept connections within 30s" >&2
+	pg_isready >&2 || true
+	ls -la /var/run/postgresql/ >&2 || true
+	pg_ctl status >&2 || true
+	exit 1
+fi
 
 psql -d postgres -f - <<__SQL__
 ALTER SYSTEM set log_statement to 'all';


### PR DESCRIPTION
Moves `postgres_versions` in `build_scripts/versions.yaml` off the May 2026 set
(18.4/17.10/16.14) and onto the 2026-08-13 set, so the cloud image can be built
with the minors the September maintenance event is scheduled to roll out. PG15
is deliberately left on 15.18 — see the comment below.

18.5 is skipped deliberately — upstream states it "was not shipped due to a
regression" and went 18.4 -> 18.6. Noted inline so it does not read as a typo.

Also replaces the GitHub-hosted `ubuntu-22.04`/`ubuntu-latest` runners and the
self-hosted `cloud-image-runner-arm64` label with RunsOn fleets sized per job,
each gaining `runs-on/action@46910bf` (v2.3.0) as its first step.

```console
$ git grep -n 'runs-on: runs-on/\|runs_on: runs-on/' -- .github/workflows
.github/workflows/build_branch.yaml:33:            runs_on: runs-on/fleet=linux-8cpu-x64/env=ue1   # was ubuntu-22.04
.github/workflows/build_branch.yaml:35:            runs_on: runs-on/fleet=linux-8cpu/env=ue1       # was cloud-image-runner-arm64
.github/workflows/build_branch.yaml:87:    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1           # was ubuntu-latest
.github/workflows/publish_check.yaml:24:    runs-on: runs-on/fleet=linux-8cpu-x64/env=ue1           # was ubuntu-22.04
.github/workflows/publish_images.yaml:42:            runs_on: runs-on/fleet=linux-8cpu-x64/env=ue1  # was ubuntu-22.04
.github/workflows/publish_images.yaml:44:            runs_on: runs-on/fleet=linux-8cpu/env=ue1      # was cloud-image-runner-arm64
.github/workflows/publish_images.yaml:112:    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1          # was ubuntu-latest
.github/workflows/publish_images.yaml:175:    runs-on: runs-on/fleet=linux-4cpu-x64/env=ue1          # was ubuntu-latest
.github/workflows/publish_images.yaml:219:    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1          # was ubuntu-latest
.github/workflows/test-shell-scripts.yaml:8:    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1        # was ubuntu-latest

$ gh api repos/timescale/timescaledb-docker-ha/actions/runs/34122683737/jobs \
    --jq '.jobs[] | "\(.name)\t\(.runner_name)"'
Dry run pg18-all amd64	runs-on--i-05c377a6e72d62628--aed326d8-3
```
