### PR TITLE
chore: add pgvectorscale 0.9.1

### DIFF
--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -228,3 +228,7 @@ pgvectorscale:
     pg-min: 14
     pg-max: 18
     cargo-pgrx: 0.16.1
+  0.9.1:
+    pg-min: 14
+    pg-max: 18
+    cargo-pgrx: 0.16.1


### PR DESCRIPTION
Add pgvectorscale 0.9.1 to the supported version matrix in `build_scripts/versions.yaml`, for PostgreSQL 14-18 with cargo-pgrx 0.16.1, matching the 0.9.0 entry.

0.9.1 is a security-hardening release: https://github.com/timescale/pgvectorscale/releases/tag/0.9.1. The release assets the install script downloads (`pgvectorscale-0.9.1-pg{14..18}-{amd64,arm64}.zip`) are published and each contains the package and dbgsym `.deb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)