### PR TITLE
Build on runs-on 16 cpu runners with a shared layer cache

### DIFF
--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -30,11 +30,13 @@ jobs:
         platform: [ amd64, arm64 ]
         include:
           - platform: amd64
-            runs_on: ubuntu-22.04
+            runs_on: runs-on/fleet=linux-16cpu-x64/env=ue1
           - platform: arm64
-            runs_on: cloud-image-runner-arm64
+            runs_on: runs-on/fleet=linux-16cpu/env=ue1
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       # Free up disk space on the runner. The pg18-all builds in particular need
       # a lot of space due to 4 PG versions worth of extensions and debug symbols.
       - name: remove unneeded runner software
@@ -64,6 +66,7 @@ jobs:
       - name: Build
         env:
           PLATFORM: ${{ matrix.platform }}
+          DOCKER_CACHE_SCOPE: pg${{ env.PG_MAJOR }}-all-${{ matrix.platform }}
         run: make build-sha
 
       - name: Check

--- a/.github/workflows/publish_check.yaml
+++ b/.github/workflows/publish_check.yaml
@@ -21,9 +21,11 @@ jobs:
   # disk space, build, and manifest issues before they hit the publish workflow.
   publish-check:
     name: Dry run pg18-all amd64
-    runs-on: ubuntu-22.04
+    runs-on: runs-on/fleet=linux-16cpu-x64/env=ue1
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       - name: remove unneeded runner software
         run: |
           df -h
@@ -60,6 +62,7 @@ jobs:
           ALL_VERSIONS: "true"
           OSS_ONLY: "false"
           DOCKER_TAG_POSTFIX: "-cicheck"
+          DOCKER_CACHE_SCOPE: pg18-all-amd64
         run: |
           make publish-builder
           docker builder prune --force || true

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -38,14 +38,17 @@ jobs:
             oss: "-oss"
           - all_versions: "true"
             all: "-all"
+          # on-demand fleets: a spot interruption would cost a 3 hour build
           - platform: amd64
-            runs_on: ubuntu-22.04
+            runs_on: runs-on/fleet=linux-16cpu-x64-ondemand/env=ue1
           - platform: arm64
-            runs_on: cloud-image-runner-arm64
+            runs_on: runs-on/fleet=linux-16cpu-ondemand/env=ue1
 
     runs-on: "${{ matrix.runs_on }}"
 
     steps:
+      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
+
       # Free up disk space on the runner. The pg18-all builds in particular need
       # a lot of space due to 4 PG versions worth of extensions and debug symbols.
       - name: remove unneeded runner software
@@ -76,6 +79,8 @@ jobs:
             [worker.oci]
               maxParallelism = 2
 
+      # The publish build writes the layer cache for the branch and PR builds
+      # but does not read it, so every publish picks up upstream package updates.
       - name: Build and publish (pg${{ matrix.pg_major }}${{ matrix.all }}${{ matrix.oss }} ${{ matrix.platform }})
         id: build
         env:
@@ -83,6 +88,8 @@ jobs:
           PG_MAJOR: ${{ matrix.pg_major }}
           ALL_VERSIONS: ${{ matrix.all_versions }}
           OSS_ONLY: ${{ matrix.oss_only }}
+          DOCKER_CACHE_SCOPE: pg${{ matrix.pg_major }}${{ matrix.all }}${{ matrix.oss }}-${{ matrix.platform }}
+          DOCKER_CACHE_FROM: "false"
         run: |
           GIT_REV="${GITHUB_REF#refs/tags/}" make publish-builder
           docker builder prune --force || true

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,25 @@ ifeq ($(strip $(USE_DOCKER_CACHE)),true)
 else
   DOCKER_CACHE := --no-cache
 endif
+# Share layers between builds through the runs-on S3 cache bucket. The
+# runs-on/action step exports RUNS_ON_S3_BUCKET_CACHE, RUNS_ON_S3_CACHE_REPO_PREFIX
+# and RUNS_ON_AWS_REGION; the runner's IAM role grants access. CI sets
+# DOCKER_CACHE_SCOPE per image variant and platform; the blobs are shared
+# between scopes, the cache manifest is per scope.
+# DOCKER_CACHE_FROM=false writes the cache but does not read it: the publish
+# build must pick up upstream package updates, a cached apt layer would not.
+DOCKER_CACHE_SCOPE?=
+DOCKER_CACHE_FROM?=true
+ifneq ($(strip $(DOCKER_CACHE_SCOPE)),)
+  ifeq ($(strip $(RUNS_ON_S3_BUCKET_CACHE)),)
+    $(error DOCKER_CACHE_SCOPE is set but RUNS_ON_S3_BUCKET_CACHE is not; this needs a runs-on runner with the s3-cache extra)
+  endif
+  DOCKER_CACHE_S3=type=s3,region=$(RUNS_ON_AWS_REGION),bucket=$(RUNS_ON_S3_BUCKET_CACHE),blobs_prefix=$(RUNS_ON_S3_CACHE_REPO_PREFIX)/buildkit/blobs/,manifests_prefix=$(RUNS_ON_S3_CACHE_REPO_PREFIX)/buildkit/manifests/,name=$(DOCKER_CACHE_SCOPE)
+  ifneq ($(strip $(DOCKER_CACHE_FROM)),false)
+    DOCKER_CACHE += --cache-from $(DOCKER_CACHE_S3)
+  endif
+  DOCKER_CACHE += --cache-to $(DOCKER_CACHE_S3),mode=max
+endif
 
 ifeq ($(ALL_VERSIONS),true)
   DOCKER_TAG_POSTFIX := $(strip $(DOCKER_TAG_POSTFIX))-all


### PR DESCRIPTION
## Summary

Stacked on #698. Moves the image builds to runs-on fleet runners and shares the BuildKit layer cache between builds through the runs-on S3 cache bucket.

## Changes

1. **Runners.** The build jobs in `publish_images`, `publish_check`, and `build_branch` run on runs-on fleet runners (`runs-on/fleet=<name>/env=ue1`):

   | Workflow | amd64 | arm64 |
   |---|---|---|
   | `build_branch`, `publish_check` | `linux-16cpu-x64` | `linux-16cpu` |
   | `publish_images` | `linux-16cpu-x64-ondemand` | `linux-16cpu-ondemand` |

   Publish uses the on-demand fleets so a spot interruption cannot cost a 3 hour build. The `runs-on/action` step is added before checkout. The `linux-16cpu-x64` and the two on-demand fleets are new in the runs-on config (savannah-infra, branch `runson-ubuntu24-shapes`) and must be applied before this merges.

2. **Layer cache.** The Makefile adds `--cache-from` and `--cache-to type=s3,...` when `DOCKER_CACHE_SCOPE` is set. Bucket, prefix and region come from the `RUNS_ON_S3_BUCKET_CACHE`, `RUNS_ON_S3_CACHE_REPO_PREFIX` and `RUNS_ON_AWS_REGION` variables that `runs-on/action` exports; the runner's IAM role grants access, so no token or extra action is needed. Each image variant and platform gets its own cache manifest (`name=pg18-all-amd64`), the blobs are shared.

3. **Cache policy.**
   - `build_branch` and `publish_check` read and write the cache.
   - `publish_images` only writes it (`DOCKER_CACHE_FROM=false`). BuildKit caches a `RUN apt-get update; apt-get upgrade` layer by its text, not its result. A publish that read the cache would ship stale packages until someone edited the Dockerfile above that line. The weekly publish exists to pick up upstream updates, so it stays cold and seeds fresh layers for the following PR builds.

## Expected effect

With #698, a version bump PR rebuilds only the new version's layer. Everything else comes from the cache written by the last publish. Cold publish builds stay long but run on 16 cpu instead of 4.

## To verify

- The `publish_check` run on this PR proves the fleet labels and the cache export. A second push to the branch should then show the extension layers as `CACHED`.
- Fork PRs already need approval before any workflow runs (`fork-pr-contributor-approval` is `all_external_contributors` on the repo), so no fork reaches these runners without a maintainer approving the run.

## Follow-ups outside this repo

- Apply the runs-on config change that adds the `16cpu-linux-x64` shape, the 16 cpu on-demand shapes, and the `linux-16cpu-x64`, `linux-16cpu-ondemand`, `linux-16cpu-x64-ondemand` fleets (200 GB volumes).
