### PR TITLE
fix: retry apt fetches instead of failing the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,11 @@ RUN adduser --home /home/postgres --uid 1000 --disabled-password --gecos "" post
 RUN echo 'APT::Install-Recommends "false";' >> /etc/apt/apt.conf.d/01norecommend
 RUN echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf.d/01norecommend
 
+# The AWS mirror intermittently serves a Packages.gz whose size disagrees with
+# the Release file it just served ("Mirror sync in progress?"), and intermittently
+# refuses connections outright. apt treats both as fatal on the first attempt.
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/02retries
+
 # Ubuntu will throttle downloads which can slow things down so much that we can't complete. Since we're
 # building in AWS, use their mirrors. arm64 and amd64 use different sources though
 COPY sources /tmp/sources


### PR DESCRIPTION
Sets `Acquire::Retries "5"` in the builder stage, so a transient failure from
`us-east-1.ec2.archive.ubuntu.com` is retried instead of killing an 80-minute
build on the first attempt. apt currently has no retry configured.

Three distinct failures from that mirror today, all fatal on first attempt:

```console
# 34152641192, master, "Publish pg16-oss amd64" — index changed mid-sync
E: Failed to fetch .../jammy-updates/main/binary-amd64/Packages.gz
   File has unexpected size (4622600 != 4622601). Mirror sync in progress?

# 34152641192, master, "Publish pg17-all-oss amd64" — same, one byte the other way
E: Failed to fetch .../jammy-updates/universe/binary-amd64/Packages.gz
   File has unexpected size (1619687 != 1619686). Mirror sync in progress?

# 33880840322, PR #696 — connection dropped mid-download
E: Failed to fetch .../lz4_1.9.3-2build2_amd64.deb  Connection failed
Fetched 52.2 MB in 49min 39s (17.5 kB/s)
```

`publish_images` fans out to 32 jobs against that one mirror at once, so at
least one catching it mid-sync is likely rather than rare — in 34152641192,
11 jobs built the identical layer successfully while these 2 failed.

This does not fix the mirror being slow: the 17.5 kB/s case above would still
take ~50 minutes, it just would not fail at the end. Only the fatal-on-first-
attempt behaviour changes.
