### PR TITLE
fix: use an existing runner fleet for image checks

### DIFF
--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -172,7 +172,7 @@ jobs:
   check:
     name: Check image pg${{ matrix.pg_major }}${{ matrix.docker_tag_postfix }}
     needs: [ "publish", "publish-combined-manifests" ]
-    runs-on: runs-on/fleet=linux-4cpu-x64/env=ue1
+    runs-on: runs-on/fleet=linux-8cpu-x64/env=ue1
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Points the `check` job at `linux-8cpu-x64` instead of `linux-4cpu-x64`, which is
not a fleet that exists. The RunsOn migration mapped this job from `ubuntu-latest`
to a fleet size the stack never defined, so RunsOn matches nothing, no instance is
ever provisioned, and all 16 `Check image` jobs queue until something cancels them.

```console
# every fleet defined for runs-on-fleet-ue1
$ gh api repos/timescale/savannah-infra/contents/env/aws-ci/us-east-1/runson/config.yaml \
    --jq '.content' | base64 -d | sed -n '176,205p' | grep -E '^\s{4}[a-z0-9-]+:'
    linux-2cpu          linux-2cpu-x64          linux-2cpu-ondemand
    linux-8cpu          linux-8cpu-x64          linux-8cpu-ondemand
    linux-16cpu                                 linux-2cpu-x64-ondemand
    linux-32cpu
# there is no 4 vCPU fleet at all:
$ ... | grep -c 4cpu
0

# and it is referenced exactly once in the whole org - here:
$ gh search code --owner timescale 'linux-4cpu-x64'
  timescale/timescaledb-docker-ha  .github/workflows/publish_images.yaml
```

Every other label in this repo resolves and runs: `linux-8cpu-x64` (32/32 publish
jobs), `linux-8cpu` (arm64 publish), `linux-2cpu-x64` (16/16 manifests). Only the
`check` job has never once been picked up - it queued 9h14m on run 34152641192
before being cancelled, then queued again on the re-run.

`linux-8cpu-x64` rather than `linux-2cpu-x64` because this job pulls both the
amd64 and arm64 variants of the `pg*-all` images and already needs a disk-cleanup
step to fit.
