### PR TITLE
fix: register binfmt in the step that emulates arm64

### DIFF
--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -202,15 +202,19 @@ jobs:
           username: ${{ secrets.ORG_DOCKER_HUB_USERNAME }}
           password: ${{ secrets.ORG_DOCKER_HUB_ACCESS_TOKEN }}
 
-      # QEMU for multiplatform, which should be quick enough for just the checks
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
       - name: Check pg${{ matrix.pg_major }}${{ matrix.docker_tag_postfix }}
         env:
           PG_MAJOR: ${{ matrix.pg_major }}
           DOCKER_TAG_POSTFIX: ${{ matrix.docker_tag_postfix }}
-        run: make get-image-config check
+        run: |
+          # QEMU for the emulated arm64 half of the check. binfmt registration
+          # does not survive a step boundary on the Ubuntu 26.04 AMI, so it has
+          # to happen in the same step that uses it; setup-qemu-action registers
+          # successfully but the handlers are gone by the next step.
+          docker run --rm --privileged \
+            tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 \
+            --install arm64
+          make get-image-config check
 
   dispatch-ha-image-published-event:
     name: Dispatch HA image published event


### PR DESCRIPTION
Replaces `docker/setup-qemu-action` in the `check` job with an inline
`tonistiigi/binfmt --install arm64` in the same step as `make check`. The action
registers the handlers correctly, but they are gone by the time the next step
runs, so the emulated arm64 half of the check has been failing since the RunsOn
migration put these jobs on the Ubuntu 26.04 AMI.

```console
# the action itself succeeds:
$ docker run --rm --privileged tonistiigi/binfmt:latest --install all
installing: arm64 OK
"supported": [ ..., "linux/arm64", ... ]

# but in the NEXT step the handler is gone:
$ ls /proc/sys/fs/binfmt_misc/
register
status
$ docker run --rm --platform linux/arm64 alpine uname -m
exec /bin/uname: exec format error

# and that is exactly how the check job dies - the arm64 container
# exits instantly, 17s before the first exec reaches it:
Error response from daemon: container 6137087a29e7 is not running
make: *** [Makefile:332: check] Error 1
```

It is the step boundary, not a timer - within one step the registration is
stable well past what the check needs, and systemd-binfmt is not involved:

```console
T+0   s handlers=1  arm64=aarch64
T+30  s handlers=1  arm64=aarch64
T+60  s handlers=1  arm64=aarch64
T+120 s handlers=1  arm64=aarch64
$ systemctl status systemd-binfmt.service
Active: inactive (dead)
```

The check's amd64 leg runs ~20s before the arm64 one, inside that window.
`setup-qemu-action` is left untouched in `publish-combined-manifests`, which
passes. The binfmt image is pinned by digest since it runs `--privileged`.
