### PR TITLE
fix: check each image arch on a native runner

### DIFF
--- a/.github/workflows/publish_check.yaml
+++ b/.github/workflows/publish_check.yaml
@@ -67,6 +67,19 @@ jobs:
           docker builder prune --force || true
           make publish-release
 
+      # Exercise the same `check` target master runs. Without this the target is
+      # only ever executed on a push to master, so a change to it cannot fail
+      # until after it has merged. amd64 only: this workflow builds one platform.
+      - name: Check pg18-all
+        env:
+          PG_MAJOR: "18"
+          PLATFORM: amd64
+          ALL_VERSIONS: "true"
+          OSS_ONLY: "false"
+          DOCKER_TAG_POSTFIX: "-cicheck"
+          CHECK_ARCHES: amd64
+        run: make get-image-config check
+
       - name: Validate digests for manifest compatibility
         run: |
           builder_id="${{ steps.build.outputs.builder_id }}"

--- a/.github/workflows/publish_check.yaml
+++ b/.github/workflows/publish_check.yaml
@@ -21,15 +21,17 @@ jobs:
   # disk space, build, and manifest issues before they hit the publish workflow.
   publish-check:
     name: Dry run pg18-all ${{ matrix.platform }}
+    # On-demand capacity: this job needs 1h40m on average. A required check
+    # must not run that long on spot capacity.
     runs-on: ${{ matrix.runs_on }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: amd64
-            runs_on: runs-on/fleet=linux-8cpu-x64/env=ue1
+            runs_on: runs-on/fleet=linux-8cpu-x64-ondemand/env=ue1
           - platform: arm64
-            runs_on: runs-on/fleet=linux-8cpu/env=ue1
+            runs_on: runs-on/fleet=linux-8cpu-ondemand/env=ue1
 
     steps:
       - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0

--- a/.github/workflows/publish_check.yaml
+++ b/.github/workflows/publish_check.yaml
@@ -20,8 +20,16 @@ jobs:
   # Dry-run the most demanding build variant (pg18-all = 4 PG versions) to catch
   # disk space, build, and manifest issues before they hit the publish workflow.
   publish-check:
-    name: Dry run pg18-all amd64
-    runs-on: runs-on/fleet=linux-8cpu-x64/env=ue1
+    name: Dry run pg18-all ${{ matrix.platform }}
+    runs-on: ${{ matrix.runs_on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: amd64
+            runs_on: runs-on/fleet=linux-8cpu-x64/env=ue1
+          - platform: arm64
+            runs_on: runs-on/fleet=linux-8cpu/env=ue1
 
     steps:
       - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
@@ -57,7 +65,7 @@ jobs:
       - name: Build and push
         id: build
         env:
-          PLATFORM: amd64
+          PLATFORM: ${{ matrix.platform }}
           PG_MAJOR: "18"
           ALL_VERSIONS: "true"
           OSS_ONLY: "false"
@@ -70,17 +78,16 @@ jobs:
       # Exercise the same `check` target master runs. Without this the target is
       # only ever executed on a push to master, so a change to it cannot fail
       # until after it has merged. amd64 only: this workflow builds one platform.
-      - name: Check pg18-all
+      - name: Check pg18-all ${{ matrix.platform }}
         env:
           PG_MAJOR: "18"
-          PLATFORM: amd64
+          PLATFORM: ${{ matrix.platform }}
           OSS_ONLY: "false"
-          # This workflow builds a single platform and never runs publish-manifests,
-          # so the multi-arch tag is never pushed - only the arch-suffixed one. Spell
-          # it out here rather than letting ALL_VERSIONS append -all to a tag that
-          # does not exist.
-          DOCKER_TAG_POSTFIX: "-cicheck-all-amd64"
-          CHECK_ARCHES: amd64
+          # Each leg builds one platform and never runs publish-manifests, so the
+          # multi-arch tag is never pushed - only the arch-suffixed one. Spell it out
+          # rather than letting ALL_VERSIONS append -all to a tag that does not exist.
+          DOCKER_TAG_POSTFIX: "-cicheck-all-${{ matrix.platform }}"
+          CHECK_ARCHES: ${{ matrix.platform }}
         run: make get-image-config check
 
       - name: Validate digests for manifest compatibility

--- a/.github/workflows/publish_check.yaml
+++ b/.github/workflows/publish_check.yaml
@@ -74,9 +74,12 @@ jobs:
         env:
           PG_MAJOR: "18"
           PLATFORM: amd64
-          ALL_VERSIONS: "true"
           OSS_ONLY: "false"
-          DOCKER_TAG_POSTFIX: "-cicheck"
+          # This workflow builds a single platform and never runs publish-manifests,
+          # so the multi-arch tag is never pushed - only the arch-suffixed one. Spell
+          # it out here rather than letting ALL_VERSIONS append -all to a tag that
+          # does not exist.
+          DOCKER_TAG_POSTFIX: "-cicheck-all-amd64"
           CHECK_ARCHES: amd64
         run: make get-image-config check
 

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -38,10 +38,13 @@ jobs:
             oss: "-oss"
           - all_versions: "true"
             all: "-all"
+          # On-demand capacity: these runs need up to 2 hours. The weekly
+          # publish also builds cold on purpose, so an interruption
+          # rebuilds every layer.
           - platform: amd64
-            runs_on: runs-on/fleet=linux-8cpu-x64/env=ue1
+            runs_on: runs-on/fleet=linux-8cpu-x64-ondemand/env=ue1
           - platform: arm64
-            runs_on: runs-on/fleet=linux-8cpu/env=ue1
+            runs_on: runs-on/fleet=linux-8cpu-ondemand/env=ue1
 
     runs-on: "${{ matrix.runs_on }}"
 

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -170,14 +170,20 @@ jobs:
         run: make publish-manifests
 
   check:
-    name: Check image pg${{ matrix.pg_major }}${{ matrix.docker_tag_postfix }}
+    name: Check image pg${{ matrix.pg_major }}${{ matrix.docker_tag_postfix }} ${{ matrix.arch }}
     needs: [ "publish", "publish-combined-manifests" ]
-    runs-on: runs-on/fleet=linux-8cpu-x64/env=ue1
+    runs-on: ${{ matrix.runs_on }}
     strategy:
       fail-fast: false
       matrix:
         pg_major: [ "18", "17", "16", "15" ]
         docker_tag_postfix: ["", "-all", "-oss", "-all-oss" ]
+        arch: [ amd64, arm64 ]
+        include:
+          - arch: amd64
+            runs_on: runs-on/fleet=linux-8cpu-x64/env=ue1
+          - arch: arm64
+            runs_on: runs-on/fleet=linux-8cpu/env=ue1
 
     steps:
       - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
@@ -206,15 +212,9 @@ jobs:
         env:
           PG_MAJOR: ${{ matrix.pg_major }}
           DOCKER_TAG_POSTFIX: ${{ matrix.docker_tag_postfix }}
-        run: |
-          # QEMU for the emulated arm64 half of the check. binfmt registration
-          # does not survive a step boundary on the Ubuntu 26.04 AMI, so it has
-          # to happen in the same step that uses it; setup-qemu-action registers
-          # successfully but the handlers are gone by the next step.
-          docker run --rm --privileged \
-            tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 \
-            --install arm64
-          make get-image-config check
+          CHECK_ARCHES: ${{ matrix.arch }}
+          PLATFORM: ${{ matrix.arch }}
+        run: make get-image-config check
 
   dispatch-ha-image-published-event:
     name: Dispatch HA image published event

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -158,10 +158,6 @@ jobs:
           username: ${{ secrets.ORG_DOCKER_HUB_USERNAME }}
           password: ${{ secrets.ORG_DOCKER_HUB_ACCESS_TOKEN }}
 
-      # QEMU for multiplatform, which should be quick enough for pulling version information out of the images
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
       - name: Publish combined manifest for pg${{ matrix.pg_major }}${{ matrix.docker_tag_postfix }}
         env:
           PG_MAJOR: ${{ matrix.pg_major }}

--- a/Makefile
+++ b/Makefile
@@ -327,10 +327,14 @@ publish-combined-sha: is_ci # publish a combined image manifest for a CICD branc
 	echo "Pushed $(CICD_URL) (amd:$$amddigest_image, arm:$$armdigest_image)" >> "$(GITHUB_STEP_SUMMARY)"
 
 CHECK_NAME=ha-check
+# Which architectures `check` verifies. Callers that run on a native runner of
+# one architecture override this so nothing has to be emulated.
+CHECK_ARCHES?=amd64 arm64
+
 .PHONY: check
 check: # check images to see if they have all the requested content
 	@set -x
-	for arch in amd64 arm64; do
+	for arch in $(CHECK_ARCHES); do
 		key="$$(mktemp -u XXXXXX)"
 		check_name="$(CHECK_NAME)-$$key"
 		echo "### Checking $$arch $(DOCKER_RELEASE_URL)" >> $(GITHUB_STEP_SUMMARY)
@@ -351,8 +355,8 @@ check: # check images to see if they have all the requested content
 		docker exec -e GITHUB_STEP_SUMMARY="/tmp/step_summary-$$key" -e CI="$(CI)" "$$check_name" /cicd/install_checks -v || { docker logs -n100 "$$check_name"; exit 1; }
 		docker exec "$$check_name" cat "/tmp/step_summary-$$key" >> "$(GITHUB_STEP_SUMMARY)" 2>&1
 		docker rm --force "$$check_name" >&/dev/null || true
-		# Drop the image before pulling the next arch; the pg*-all images are
-		# large enough that holding both amd64 and arm64 at once fills the disk.
+		# Drop the image once checked; the pg*-all images are large enough that
+		# keeping them around fills the disk.
 		docker rmi --force "$(DOCKER_RELEASE_URL)" >&/dev/null || true
 	done
 


### PR DESCRIPTION
Runs the `check` job once per architecture on a runner of that architecture,
instead of once per variant on an x64 runner that emulates arm64 through QEMU.
The arm64 images are already built on `linux-8cpu` (native arm64), so nothing
here needed emulating in the first place.

Emulation is what has been failing. The container exits the moment it starts,
because binfmt is not registered:

```console
# on the master run, every one of the 16 check jobs:
+ docker run --platform linux/arm64 ... timescaledb-ha:pg18 sleep 300
Error response from daemon: container fb0270ab9055 is not running
make: *** [Makefile:332: check] Error 1

# and registering it in the same step does not help - 24s later it is gone:
14:48:35  installing: arm64 OK
14:48:59  docker run --platform linux/arm64 ...
14:49:19  container ... is not running
```

That second block is #704, which I got wrong; this replaces it. The native
arm64 fleet meanwhile is healthy - 16 arm64 publish jobs succeeded in the same
run that all 16 checks failed.

`CHECK_ARCHES` defaults to `amd64 arm64`, so anyone running `make check`
locally still gets both.

`publish_check.yaml` also becomes a two-platform matrix, so both check legs -
including arm64 on `linux-8cpu` - run before merge rather than first executing
on master. `make check` previously only ever ran on a push to master, which is
exactly how #704 reached master. The legs run in parallel, so wall-clock is
roughly unchanged.

Each leg builds and checks only its own arch tag:

```console
### amd64
  build pushes:  timescaledb-ha:pg18-cicheck-all-amd64
  check pulls:   timescaledb-ha:pg18-cicheck-all-amd64
  arch iterated: for arch in amd64
### arm64
  build pushes:  timescaledb-ha:pg18-cicheck-all-arm64
  check pulls:   timescaledb-ha:pg18-cicheck-all-arm64
  arch iterated: for arch in arm64
```

The arch suffix has to be spelled out for the check step: this workflow never
runs `publish-manifests`, so the multi-arch tag is never pushed and only the
arch-suffixed one exists. The first revision of this PR got that wrong and its
own new step caught it.

Finally, drops the last `setup-qemu-action`, in `publish-combined-manifests`.
Its comment claims it is for "pulling version information out of the images",
but `version_info` arrives as a downloaded artifact, so `$(VERSION_INFO)` is
already satisfied and never runs a container - the job is registry calls plus
`awk` on a text file:

```console
+ cat /tmp/outputs/version_info
++ awk -F = '/postgresql.version=/ {print $2}' /tmp/outputs/version_info
+ docker manifest create ...pg16-oss-builder --amend ...@sha256:b7be08 --amend ...@sha256:d68085
```

It was pulling `tonistiigi/binfmt` and running `--install all` on all 16
manifest jobs of every publish run for nothing. Nothing in the repo emulates
now:

```console
$ grep -rn 'setup-qemu-action\|tonistiigi/binfmt\|binfmt' .github/workflows/ Makefile
$
```
