### PR TITLE
ci: run long publish jobs on on-demand runners

### DIFF
--- a/.github/workflows/publish_check.yaml
+++ b/.github/workflows/publish_check.yaml
@@ -21,15 +21,17 @@ jobs:
   # disk space, build, and manifest issues before they hit the publish workflow.
   publish-check:
     name: Dry run pg18-all ${{ matrix.platform }}
+    # On-demand capacity: this job needs 1h40m on average. A required check
+    # must not run that long on spot capacity.
     runs-on: ${{ matrix.runs_on }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: amd64
-            runs_on: runs-on/fleet=linux-8cpu-x64/env=ue1
+            runs_on: runs-on/fleet=linux-8cpu-x64-ondemand/env=ue1
           - platform: arm64
-            runs_on: runs-on/fleet=linux-8cpu/env=ue1
+            runs_on: runs-on/fleet=linux-8cpu-ondemand/env=ue1
 
     steps:
       - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -38,10 +38,13 @@ jobs:
             oss: "-oss"
           - all_versions: "true"
             all: "-all"
+          # On-demand capacity: these runs need up to 2 hours. The weekly
+          # publish also builds cold on purpose, so an interruption
+          # rebuilds every layer.
           - platform: amd64
-            runs_on: runs-on/fleet=linux-8cpu-x64/env=ue1
+            runs_on: runs-on/fleet=linux-8cpu-x64-ondemand/env=ue1
           - platform: arm64
-            runs_on: runs-on/fleet=linux-8cpu/env=ue1
+            runs_on: runs-on/fleet=linux-8cpu-ondemand/env=ue1
 
     runs-on: "${{ matrix.runs_on }}"
 


### PR DESCRIPTION
- The pg*-all runs need 1 to 2 hours.
- The weekly publish sets DOCKER_CACHE_FROM=false, so a restart after an interruption rebuilds every layer.
- The manifest, check and shell-test jobs stay on spot. None of them runs long enough for an interruption to cost anything.