### PR TITLE
chore: include timescaledb v2.30.0 in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -423,7 +423,7 @@ RUN <<EOF
 /build/scripts/install_extensions timescaledb 2.23.0 "15 16 17 18"
 /build/scripts/install_extensions timescaledb 2.23.1 "15 16 17 18"
 EOF
-# 2.24.x
+# older deb releases, one layer for all
 RUN <<EOF
 /build/scripts/install_extensions timescaledb 2.24.0 "15 16 17 18"
 EOF
@@ -459,6 +459,10 @@ RUN <<EOF
 /build/scripts/install_extensions timescaledb 2.29.0 "16 17 18"
 /build/scripts/install_extensions timescaledb 2.29.1 "16 17 18"
 /build/scripts/install_extensions timescaledb 2.29.2 "16 17 18"
+EOF
+# 2.30.x
+RUN <<EOF
+/build/scripts/install_extensions timescaledb 2.30.0 "16 17 18"
 EOF
 # END GENERATED timescaledb
 

--- a/build_scripts/versions.yaml
+++ b/build_scripts/versions.yaml
@@ -163,6 +163,9 @@ timescaledb:
   2.29.2:
     pg-min: 16
     pg-max: 18
+  2.30.0:
+    pg-min: 16
+    pg-max: 18
 #   # main is the tip of timescaledb
 #   main:
 #    pg-min: 16


### PR DESCRIPTION
we've recently built the new image, ship it now.