### PR TITLE
perf: use the tarballs for OSS images and check inside the publish job

### DIFF
--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -92,6 +92,20 @@ jobs:
           GIT_REV="${GITHUB_REF#refs/tags/}" make publish-builder
           GIT_REV="${GITHUB_REF#refs/tags/}" make publish-release
 
+      # Checks the image this job pushed, by digest. The check job that ran after
+      # the manifests pulled every image again on a fresh runner.
+      - name: Check pg${{ matrix.pg_major }}${{ matrix.all }}${{ matrix.oss }} ${{ matrix.platform }}
+        env:
+          PG_MAJOR: ${{ matrix.pg_major }}
+          PLATFORM: ${{ matrix.platform }}
+          CHECK_ARCHES: ${{ matrix.platform }}
+          # The multi-arch tag does not exist yet, only the arch-suffixed one.
+          # Spell the postfix out; ALL_VERSIONS and OSS_ONLY would append to it.
+          ALL_VERSIONS: "false"
+          OSS_ONLY: "false"
+          DOCKER_TAG_POSTFIX: "${{ matrix.all }}${{ matrix.oss }}-${{ matrix.platform }}"
+        run: make check
+
       - name: export outputs
         run: |
           mkdir -p /tmp/outputs
@@ -167,45 +181,9 @@ jobs:
           DOCKER_TAG_POSTFIX: ${{ matrix.docker_tag_postfix }}
         run: make publish-manifests
 
-  check:
-    name: Check image pg${{ matrix.pg_major }}${{ matrix.docker_tag_postfix }} ${{ matrix.arch }}
-    needs: [ "publish", "publish-combined-manifests" ]
-    runs-on: ${{ matrix.runs_on }}
-    strategy:
-      fail-fast: false
-      matrix:
-        pg_major: [ "18", "17", "16", "15" ]
-        docker_tag_postfix: ["", "-all", "-oss", "-all-oss" ]
-        arch: [ amd64, arm64 ]
-        include:
-          - arch: amd64
-            runs_on: runs-on/fleet=linux-8cpu-x64/env=ue1
-          - arch: arm64
-            runs_on: runs-on/fleet=linux-8cpu/env=ue1
-
-    steps:
-      - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0
-
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
-        with:
-          username: ${{ secrets.ORG_DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.ORG_DOCKER_HUB_ACCESS_TOKEN }}
-
-      - name: Check pg${{ matrix.pg_major }}${{ matrix.docker_tag_postfix }}
-        env:
-          PG_MAJOR: ${{ matrix.pg_major }}
-          DOCKER_TAG_POSTFIX: ${{ matrix.docker_tag_postfix }}
-          CHECK_ARCHES: ${{ matrix.arch }}
-          PLATFORM: ${{ matrix.arch }}
-        run: make get-image-config check
-
   dispatch-ha-image-published-event:
     name: Dispatch HA image published event
-    needs: [ "check" ]
+    needs: [ "publish-combined-manifests" ]
     if: ${{ github.event_name == 'push' }}
     runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
 

--- a/Makefile
+++ b/Makefile
@@ -217,15 +217,12 @@ EXTENSION_ARTIFACTS_DIR=build_artifacts/$(PLATFORM)
 EXTENSION_ARTIFACTS_BUCKET?=timescale-ci-artifacts
 EXTENSION_ARTIFACTS_S3=s3://$(EXTENSION_ARTIFACTS_BUCKET)/timescaledb-docker-ha/extensions/$(subst :,-,$(DOCKER_FROM))/$(PLATFORM)
 ifeq ($(EXTENSION_ARTIFACTS),true)
-  # an OSS_ONLY image has no toolkit and builds timescaledb without timescaledb-tsl
-  ifneq ($(OSS_ONLY),true)
-    # no pipe here: .SHELLSTATUS reports the last command of the pipeline
-    EXTENSION_BUILDS:=$(shell PG_VERSIONS="$(PG_VERSIONS)" TIMESCALEDB_VERSIONS="$(TIMESCALEDB_VERSIONS)" TOOLKIT_VERSIONS="$(TOOLKIT_VERSIONS)" ./build_scripts/extension_builds)
-    ifneq ($(.SHELLSTATUS),0)
-      $(error build_scripts/extension_builds failed)
-    endif
-    EXTENSION_ARTIFACT_FILES=$(addprefix $(EXTENSION_ARTIFACTS_DIR)/,$(addsuffix .tar.gz,$(EXTENSION_BUILDS)))
+  # no pipe here: .SHELLSTATUS reports the last command of the pipeline
+  EXTENSION_BUILDS:=$(shell OSS_ONLY="$(OSS_ONLY)" PG_VERSIONS="$(PG_VERSIONS)" TIMESCALEDB_VERSIONS="$(TIMESCALEDB_VERSIONS)" TOOLKIT_VERSIONS="$(TOOLKIT_VERSIONS)" ./build_scripts/extension_builds)
+  ifneq ($(.SHELLSTATUS),0)
+    $(error build_scripts/extension_builds failed)
   endif
+  EXTENSION_ARTIFACT_FILES=$(addprefix $(EXTENSION_ARTIFACTS_DIR)/,$(addsuffix .tar.gz,$(EXTENSION_BUILDS)))
   builder release build build-oss build-sha: extension-artifacts
 endif
 
@@ -380,6 +377,8 @@ publish-combined-manifest: $(VERSION_INFO)
 		docker manifest rm "$$url" || true
 		docker manifest create "$$url" "$${images[@]}"
 		docker manifest push "$$url"
+		# the publish jobs checked each image; this checks the list points at both
+		docker manifest inspect "$$url" | jq -e '([.manifests[].platform.architecture] | sort) == ["amd64", "arm64"]' > /dev/null
 		echo "Pushed $$url ($${images[@]})" | tee -a "$(GITHUB_STEP_SUMMARY)"
 	done
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ PostgreSQL major and architecture, and keeps the tarball in the CI artifacts buc
 `make extension-artifacts` fetches the tarballs into `build_artifacts/<arch>/`, builds the missing ones from the `timescaledb-artifact` and
 `toolkit-artifact` Dockerfile stages and stores them. The image build unpacks the tarballs it finds and installs
 the rest itself. Delete a tarball from the bucket to rebuild it. Without `EXTENSION_ARTIFACTS=true`, such as a
-local build, the image installs every version itself. OSS-only images do not use the tarballs: they build
-timescaledb without timescaledb-tsl.
+local build, the image installs every version itself.
 
 The scripts outside the image need `yq`, `jq` and `shellcheck`. `mise install` installs the pinned versions from
 `mise.toml`.

--- a/build_scripts/extension_builds
+++ b/build_scripts/extension_builds
@@ -3,7 +3,7 @@
 # Print "<extension>-<version>-pg<major>" for every timescaledb and toolkit
 # release the image needs. The Makefile reads this list to fetch or build the
 # extension tarballs. Branch builds (main, feature/x) are not listed: they
-# build in the image.
+# build in the image. An OSS_ONLY image has no toolkit.
 #
 # usage: TIMESCALEDB_VERSIONS=all TOOLKIT_VERSIONS=all PG_VERSIONS="18 17" extension_builds
 
@@ -18,6 +18,7 @@ for ver in $TIMESCALEDB_VERSIONS; do
         [ -z "$(supported_timescaledb "$pg" "$ver")" ] && echo "timescaledb-$ver-pg$pg"
     done
 done
+[ "$OSS_ONLY" = true ] && TOOLKIT_VERSIONS=""
 for ver in $TOOLKIT_VERSIONS; do
     [[ "$ver" =~ $release ]] || continue
     for pg in $PG_VERSIONS; do

--- a/build_scripts/shared_install.sh
+++ b/build_scripts/shared_install.sh
@@ -178,8 +178,16 @@ install_timescaledb() {
 
         log "installing $pkg-$version for pg$pg"
 
-        # the tarballs carry timescaledb-tsl, an OSS_ONLY image builds without it
-        if [ "$OSS_ONLY" != true ] && unpack_artifact "$pkg" "$version" "$pg"; then continue; fi
+        # The tarball carries timescaledb-tsl. APACHE_ONLY only leaves out the tsl
+        # directory of the build, so an OSS_ONLY image removes the file, as the deb
+        # path does.
+        if unpack_artifact "$pkg" "$version" "$pg"; then
+            if [ "$OSS_ONLY" = true ]; then
+                log "removing timescaledb-tsl due to OSS_ONLY"
+                rm -f /usr/lib/postgresql/"$pg"/lib/timescaledb-tsl-"$version".so
+            fi
+            continue
+        fi
 
         [[ "$DRYRUN" = true ]] && continue
 


### PR DESCRIPTION
## Summary

Two cuts to the publish workflow, measured on run 34390615083 (26 min wall).

## Changes

- **OSS images use the tarballs.** They unpack the same timescaledb tarball and remove `timescaledb-tsl-<version>.so`. `APACHE_ONLY` only leaves the `tsl` directory out of the build; the deb path already installs the full package and removes that file. The OSS cells built 93 timescaledb versions from source: 11.5 min, the longest publish cell (pg18-all-oss 20 min vs pg18-all 13 min). OSS images list no toolkit tarballs.
- **The publish job checks its own image** right after the push, by digest. The check matrix that ran after the manifests pulled every image again on 32 fresh runners: about 4 min of wall time. The manifest step now asserts that each pushed manifest list points at both architectures, which is what the old check job proved beyond the per-image checks.

## Expected

Publish wall time ~26 min → ~15 min. 32 fewer runner boots per publish.

## Verification

- Local, arm64 pg18 OSS: `make build-oss` from tarballs on disk logged `unpacked` and `removing timescaledb-tsl` for 2.23.1 and 2.29.2, skipped toolkit, and passed the in-image checks.
- Dry run of an OSS pg18-all cell: sync plus 169 timescaledb tarball rules, no toolkit.
- The publish workflow only runs on master, so the check-in-publish path is proven by the first publish after merge.
