### PR TITLE
ci: run the utility jobs on the arm64 2cpu fleet

### DIFF
--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -76,7 +76,7 @@ jobs:
   publish-combined-manifest:
     name: Publish branch manifest
     needs: [ "build-branch" ]
-    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
 
     steps:
       - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -125,7 +125,7 @@ jobs:
   publish-combined-manifests:
     name: Publish manifest pg${{ matrix.pg_major }}${{ matrix.docker_tag_postfix }}
     needs: [ "publish" ]
-    runs-on: runs-on/fleet=linux-2cpu/env=ue1
+    runs-on: runs-on/fleet=linux-2cpu-ondemand/env=ue1
     strategy:
       fail-fast: false
 
@@ -185,7 +185,7 @@ jobs:
     name: Dispatch HA image published event
     needs: [ "publish-combined-manifests" ]
     if: ${{ github.event_name == 'push' }}
-    runs-on: runs-on/fleet=linux-2cpu/env=ue1
+    runs-on: runs-on/fleet=linux-2cpu-ondemand/env=ue1
 
     steps:
       - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -125,7 +125,7 @@ jobs:
   publish-combined-manifests:
     name: Publish manifest pg${{ matrix.pg_major }}${{ matrix.docker_tag_postfix }}
     needs: [ "publish" ]
-    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     strategy:
       fail-fast: false
 
@@ -185,7 +185,7 @@ jobs:
     name: Dispatch HA image published event
     needs: [ "publish-combined-manifests" ]
     if: ${{ github.event_name == 'push' }}
-    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
 
     steps:
       - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0

--- a/.github/workflows/test-shell-scripts.yaml
+++ b/.github/workflows/test-shell-scripts.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   tests:
     name: Test System Services
-    runs-on: runs-on/fleet=linux-2cpu-x64/env=ue1
+    runs-on: runs-on/fleet=linux-2cpu/env=ue1
     timeout-minutes: 2
     steps:
       - uses: runs-on/action@46910bf61b41721b0579f237e186afb35477007a # v2.3.0


### PR DESCRIPTION
Shell tests, the manifest jobs and the dispatch curl do not depend on the architecture, so they move to the arm64 2cpu fleets. The publish workflow's jobs use the on-demand fleet, the branch jobs spot. No change for the build jobs.