### PR TITLE
ci: use the type=gha BuildKit cache backed by the runs-on Magic Cache

### DIFF
--- a/.github/workflows/build_branch.yaml
+++ b/.github/workflows/build_branch.yaml
@@ -55,11 +55,20 @@ jobs:
             [worker.oci]
               maxParallelism = 2
 
+      # docker buildx reads the GitHub Actions cache API from these variables.
+      # The runner only gives them to actions, so this step exports them.
+      - name: Setup | Actions cache variables
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            for (const name of ['ACTIONS_CACHE_URL', 'ACTIONS_RESULTS_URL', 'ACTIONS_RUNTIME_TOKEN', 'ACTIONS_CACHE_SERVICE_V2']) {
+              if (process.env[name]) core.exportVariable(name, process.env[name]);
+            }
+
       - name: Build
         env:
           PLATFORM: ${{ matrix.platform }}
           DOCKER_CACHE_SCOPE: pg${{ env.PG_MAJOR }}-all-${{ matrix.platform }}
-          DOCKER_CACHE_BRANCH: ${{ github.head_ref || github.ref_name }}
           EXTENSION_ARTIFACTS: "true"
         run: make build-sha
 

--- a/.github/workflows/publish_check.yaml
+++ b/.github/workflows/publish_check.yaml
@@ -58,6 +58,16 @@ jobs:
             [worker.oci]
               maxParallelism = 2
 
+      # docker buildx reads the GitHub Actions cache API from these variables.
+      # The runner only gives them to actions, so this step exports them.
+      - name: Setup | Actions cache variables
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            for (const name of ['ACTIONS_CACHE_URL', 'ACTIONS_RESULTS_URL', 'ACTIONS_RUNTIME_TOKEN', 'ACTIONS_CACHE_SERVICE_V2']) {
+              if (process.env[name]) core.exportVariable(name, process.env[name]);
+            }
+
       - name: Build and push
         id: build
         env:
@@ -67,7 +77,6 @@ jobs:
           OSS_ONLY: "false"
           DOCKER_TAG_POSTFIX: "-cicheck"
           DOCKER_CACHE_SCOPE: pg18-all-${{ matrix.platform }}
-          DOCKER_CACHE_BRANCH: ${{ github.head_ref || github.ref_name }}
           EXTENSION_ARTIFACTS: "true"
         run: |
           make publish-builder

--- a/.github/workflows/publish_images.yaml
+++ b/.github/workflows/publish_images.yaml
@@ -73,6 +73,16 @@ jobs:
             [worker.oci]
               maxParallelism = 2
 
+      # docker buildx reads the GitHub Actions cache API from these variables.
+      # The runner only gives them to actions, so this step exports them.
+      - name: Setup | Actions cache variables
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            for (const name of ['ACTIONS_CACHE_URL', 'ACTIONS_RESULTS_URL', 'ACTIONS_RUNTIME_TOKEN', 'ACTIONS_CACHE_SERVICE_V2']) {
+              if (process.env[name]) core.exportVariable(name, process.env[name]);
+            }
+
       # The packages in the image are not pinned. A cached build keeps the packages
       # of the build that wrote the cache. The weekly scheduled publish builds cold
       # and refreshes them; a publish from master ships what the PR build tested.
@@ -85,7 +95,6 @@ jobs:
           ALL_VERSIONS: ${{ matrix.all_versions }}
           OSS_ONLY: ${{ matrix.oss_only }}
           DOCKER_CACHE_SCOPE: pg${{ matrix.pg_major }}${{ matrix.all }}${{ matrix.oss }}-${{ matrix.platform }}
-          DOCKER_CACHE_BRANCH: ${{ github.head_ref || github.ref_name }}
           DOCKER_CACHE_FROM: ${{ github.event_name == 'schedule' && 'false' || 'true' }}
           EXTENSION_ARTIFACTS: "true"
         run: |

--- a/Makefile
+++ b/Makefile
@@ -39,19 +39,18 @@ ifeq ($(strip $(USE_DOCKER_CACHE)),true)
 else
   DOCKER_CACHE := --no-cache
 endif
-# BuildKit layer cache in the runs-on S3 bucket (RUNS_ON_* from runs-on/action).
-# DOCKER_CACHE_SCOPE turns it on. A branch reads its own manifest and master's.
+# BuildKit layer cache through the GitHub Actions cache API. On runs-on the
+# Magic Cache serves that API from S3. The API scopes a cache to the branch,
+# its base branch and master, so a branch reads its own cache and master's.
+# The workflow exports ACTIONS_CACHE_URL, ACTIONS_RESULTS_URL and
+# ACTIONS_RUNTIME_TOKEN before the build. DOCKER_CACHE_SCOPE turns it on.
 DOCKER_CACHE_FROM?=true
-DOCKER_CACHE_BRANCH?=$(shell git rev-parse --abbrev-ref HEAD)
 ifneq ($(strip $(DOCKER_CACHE_SCOPE)),)
-  DOCKER_CACHE_S3=type=s3,region=$(RUNS_ON_AWS_REGION),bucket=$(RUNS_ON_S3_BUCKET_CACHE),blobs_prefix=$(RUNS_ON_S3_CACHE_REPO_PREFIX)/buildkit/blobs/,manifests_prefix=$(RUNS_ON_S3_CACHE_REPO_PREFIX)/buildkit/manifests/
-  DOCKER_CACHE_NAME=$(DOCKER_CACHE_SCOPE)-$(subst /,-,$(DOCKER_CACHE_BRANCH))
-  DOCKER_CACHE += --cache-to $(DOCKER_CACHE_S3),name=$(DOCKER_CACHE_NAME),mode=max
+  DOCKER_CACHE_GHA=type=gha,scope=$(DOCKER_CACHE_SCOPE)
+  DOCKER_CACHE += --cache-to $(DOCKER_CACHE_GHA),mode=max
   ifneq ($(DOCKER_CACHE_FROM),false)
-    DOCKER_CACHE_FROM_ARGS += --cache-from $(DOCKER_CACHE_S3),name=$(DOCKER_CACHE_NAME)
-    DOCKER_CACHE_FROM_ARGS += --cache-from $(DOCKER_CACHE_S3),name=$(DOCKER_CACHE_SCOPE)-master
+    DOCKER_CACHE += --cache-from $(DOCKER_CACHE_GHA)
   endif
-  DOCKER_CACHE += $(DOCKER_CACHE_FROM_ARGS)
 endif
 
 ifeq ($(ALL_VERSIONS),true)


### PR DESCRIPTION
## Summary

- Switch the BuildKit layer cache from `type=s3` (hand-built from the `RUNS_ON_*` variables) to `type=gha,scope=$DOCKER_CACHE_SCOPE`.
- The fleet runners have `extras: [s3-cache]`, so runs-on Magic Cache serves the Actions cache API from the runs-on S3 bucket in the background.
- The Actions cache API already scopes entries to the current branch, its base branch and master, so `DOCKER_CACHE_BRANCH` and the explicit `-master` `--cache-from` fallback go away.
- The Makefile calls `docker buildx build` directly, so a pinned `actions/github-script` step exports `ACTIONS_CACHE_URL`, `ACTIONS_RESULTS_URL`, `ACTIONS_RUNTIME_TOKEN` and `ACTIONS_CACHE_SERVICE_V2` to the later `run` steps. `docker/build-push-action` does this internally; a plain step does not get them.
- `DOCKER_CACHE_FROM=false` on the weekly schedule still builds cold and only writes the cache.

## Notes

- `type=gha` has a default 10m import/export timeout per build. The S3 backend had none. If the `mode=max` export of the full image trips it, add `timeout=` to `DOCKER_CACHE_GHA`.
- `actionlint` reports only the pre-existing unknown `runs-on/fleet=...` label warnings.

## Verification

`make -n` with `DOCKER_CACHE_SCOPE=pg18-all-amd64`:

```
--cache-to type=gha,scope=pg18-all-amd64,mode=max
--cache-from type=gha,scope=pg18-all-amd64
```

With `DOCKER_CACHE_FROM=false` only the `--cache-to` line remains. With no scope no cache flags are emitted.

The branch build on this PR is the first real run: check the `Setup | Actions cache variables` step and the `importing cache manifest from gha` / `exporting cache to GitHub Actions Cache` lines in the buildx log.


## Results from the branch build (run 34505948451)

Attempt 1 is cold (new cache scope). Attempt 2 is a rerun of the same commit.

| | amd64 | arm64 |
|---|---|---|
| cold build job | 12m20s | 13m43s |
| cold cache export | 107.5s | 109.6s |
| warm build job | 6m31s | 6m39s |
| warm cache export | 8.0s | 5.1s |
| warm `CACHED` steps | 61 | 61 |

Both attempts log `importing cache manifest from gha:<key>` and the export finished well inside the default 10m timeout.
